### PR TITLE
UserControllerの結合テストの実装("異常系_権限が足りない"は未対応)

### DIFF
--- a/backend/web/src/test/java/com/memoblend/web/controller/UserControllerTest.java
+++ b/backend/web/src/test/java/com/memoblend/web/controller/UserControllerTest.java
@@ -1,8 +1,140 @@
 package com.memoblend.web.controller;
 
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+import org.springframework.test.web.servlet.MockMvc;
+import com.memoblend.web.WebApplication;
+
 /**
  * {@link UserController} クラスのテストクラスです。
  */
+@SpringJUnitConfig
+@SpringBootTest(classes = WebApplication.class)
+@AutoConfigureMockMvc
 public class UserControllerTest {
 
+  @Autowired
+  MockMvc mockMvc;
+
+  @Test
+  @WithMockUser
+  public void testGetUser_正常系_ユーザーを返す() throws Exception {
+    long id = 1;
+    this.mockMvc.perform(get("/api/user/" + id))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON));
+  }
+
+  @Test
+  @WithMockUser
+  public void testGetUser_異常系_ユーザーが存在しない() throws Exception {
+    long id = 999;
+    this.mockMvc.perform(get("/api/user/" + id))
+        .andExpect(status().isNotFound());
+  }
+
+  // @Test
+  // public void testGetUser_異常系_権限が足りない() throws Exception {
+  // long id = 1;
+  // this.mockMvc.perform(get("/api/user/" + id))
+  // .andExpect(status().isNotFound());
+  // }
+
+  @Test
+  @WithMockUser
+  public void testPostUser_正常系_ユーザーを登録する() throws Exception {
+    String userJson = "{"
+        + "\"name\": \"Test name\""
+        + "}";
+    this.mockMvc.perform(post("/api/user")
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(userJson))
+        .andExpect(status().isCreated())
+        .andExpect(header().exists("Location"));
+  }
+
+  // @Test
+  // public void testPostUser_異常系_権限が足りない() throws Exception {
+  // String userJson = "{"
+  // + "\"name\": \"Test name\""
+  // + "}";
+  // this.mockMvc.perform(post("/api/user")
+  // .contentType(MediaType.APPLICATION_JSON)
+  // .content(userJson))
+  // .andExpect(status().isNotFound());
+  // }
+
+  @Test
+  @WithMockUser
+  public void testDeleteUser_正常系_ユーザーを削除する() throws Exception {
+    long id = 10;
+    this.mockMvc.perform(delete("/api/user/" + id))
+        .andExpect(status().isOk());
+  }
+
+  @Test
+  @WithMockUser
+  public void testDeleteUser_異常系_ユーザーが存在しない() throws Exception {
+    long id = 999;
+    this.mockMvc.perform(delete("/api/user/" + id))
+        .andExpect(status().isNotFound());
+  }
+
+  // @Test
+  // public void testDeleteUser_異常系_権限が足りない() throws Exception {
+  // long id = 1;
+  // this.mockMvc.perform(delete("/api/user/" + id))
+  // .andExpect(status().isNotFound());
+  // }
+
+  @Test
+  @WithMockUser
+  public void testPutUser_正常系_ユーザーを更新する() throws Exception {
+    String userJson = "{"
+        + "\"id\": 1,"
+        + "\"name\": \"Test name\""
+        + "}";
+    this.mockMvc.perform(put("/api/user")
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(userJson))
+        .andExpect(status().isOk());
+  }
+
+  @Test
+  @WithMockUser
+  public void testPutUser_異常系_ユーザーが存在しない() throws Exception {
+    String userJson = "{"
+        + "\"id\": 999,"
+        + "\"name\": \"Test name\""
+        + "}";
+    this.mockMvc.perform(put("/api/user")
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(userJson))
+        .andExpect(status().isNotFound());
+  }
+
+  // @Test
+  // public void testPutUser_異常系_権限が足りない() throws Exception {
+  // String userJson = "{"
+  // + "\"id\": 1,"
+  // + "\"name\": \"Test name\""
+  // + "}";
+  // this.mockMvc.perform(put("/api/user")
+  // .contentType(MediaType.APPLICATION_JSON)
+  // .content(userJson))
+  // .andExpect(status().isNotFound());
+  // }
 }


### PR DESCRIPTION
## 本プルリクエストで実施したこと
- UserControllerの結合テストの実装

## 本プルリクエストで実施していないこと
- "*_異常系_権限が足りない"に関しては、ユーザーの認可機能を実装していないため、コメントアウトしています。
- ※クラスに @WithMockUser を記述してもERORR発生。これは、権限を付与している状態で異常系_権限が足りないをテストしており、想定の結果と不一致しているためと考えています。
- 別途#176と#177にissueを立てています。

## 関連Issue、参考ページ
- #158
- #176
- #177
