### PR TITLE
日記ドメインの単体テスト実装

### DIFF
--- a/backend/api-docs/web/api-specification.json
+++ b/backend/api-docs/web/api-specification.json
@@ -366,9 +366,7 @@
         "required": [
           "content",
           "date",
-          "id",
-          "title",
-          "userId"
+          "title"
         ]
       },
       "GetDiariesResponse": {

--- a/backend/application-core/src/main/java/com/memoblend/applicationcore/diary/Diary.java
+++ b/backend/application-core/src/main/java/com/memoblend/applicationcore/diary/Diary.java
@@ -3,6 +3,7 @@ package com.memoblend.applicationcore.diary;
 import java.time.LocalDate;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
 import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -14,25 +15,20 @@ import lombok.Data;
 @AllArgsConstructor
 public class Diary {
 
-  @NotNull
-  //@NotBlank
+  @PositiveOrZero
   private long id;
 
-  @NotNull
-  //@NotBlank
+  @PositiveOrZero
   private long userId;
 
-  @NotNull
-  @NotBlank
+  @NotBlank(message = "{0}は1～30文字の範囲で入力してください")
   @Size(min = 1, max = 30, message = "{0}は1～30文字の範囲で入力してください")
   private String title;
 
-  @NotNull
-  @NotBlank
+  @NotBlank(message = "{0}は1文字以上入力してください")
   @Size(min = 1, message = "{0}は1文字以上入力してください")
   private String content;
 
-  @NotNull
-  //@NotBlank
+  @NotNull(message = "{0}は必須です")
   private LocalDate date;
 }

--- a/backend/application-core/src/main/java/com/memoblend/applicationcore/diary/Diary.java
+++ b/backend/application-core/src/main/java/com/memoblend/applicationcore/diary/Diary.java
@@ -15,10 +15,10 @@ import lombok.Data;
 @AllArgsConstructor
 public class Diary {
 
-  @PositiveOrZero
+  @PositiveOrZero(message = "{0}は0以上の値にしてください")
   private long id;
 
-  @PositiveOrZero
+  @PositiveOrZero(message = "{0}は0以上の値にしてください")
   private long userId;
 
   @NotBlank(message = "{0}は1～30文字の範囲で入力してください")

--- a/backend/application-core/src/main/java/com/memoblend/applicationcore/diary/Diary.java
+++ b/backend/application-core/src/main/java/com/memoblend/applicationcore/diary/Diary.java
@@ -15,11 +15,11 @@ import lombok.Data;
 public class Diary {
 
   @NotNull
-  @NotBlank
+  //@NotBlank
   private long id;
 
   @NotNull
-  @NotBlank
+  //@NotBlank
   private long userId;
 
   @NotNull
@@ -33,6 +33,6 @@ public class Diary {
   private String content;
 
   @NotNull
-  @NotBlank
+  //@NotBlank
   private LocalDate date;
 }

--- a/backend/application-core/src/main/java/com/memoblend/applicationcore/diary/Diary.java
+++ b/backend/application-core/src/main/java/com/memoblend/applicationcore/diary/Diary.java
@@ -15,9 +15,11 @@ import lombok.Data;
 @AllArgsConstructor
 public class Diary {
 
+  @NotNull(message = "{0}は必須です")
   @PositiveOrZero(message = "{0}は0以上の値にしてください")
   private long id;
 
+  @NotNull(message = "{0}は必須です")
   @PositiveOrZero(message = "{0}は0以上の値にしてください")
   private long userId;
 

--- a/backend/application-core/src/test/java/com/memoblend/applicationcore/diary/DiaryTest.java
+++ b/backend/application-core/src/test/java/com/memoblend/applicationcore/diary/DiaryTest.java
@@ -42,6 +42,16 @@ public class DiaryTest {
   }
 
   @Test
+  public void testIdSetZero_正常系_idが0() {
+    // Arrange
+    diary.setId(0L);
+    // Act
+    validator.validate(diary, bindingResult);
+    // Assert
+    assertTrue(!bindingResult.hasErrors());
+  }
+
+  @Test
   @SuppressWarnings("null")
   public void testIdIsNull_異常系_IDが負の数() {
     // Arrange
@@ -50,7 +60,17 @@ public class DiaryTest {
     validator.validate(diary, bindingResult);
     // Assert
     assertEquals("id", bindingResult.getFieldError().getField());
-    assertEquals("0 以上の値にしてください", bindingResult.getFieldError().getDefaultMessage());
+    assertEquals("{0}は0以上の値にしてください", bindingResult.getFieldError().getDefaultMessage());
+  }
+
+  @Test
+  public void testUserIdSetZero_正常系_userIdが0() {
+    // Arrange
+    diary.setUserId(0L);
+    // Act
+    validator.validate(diary, bindingResult);
+    // Assert
+    assertTrue(!bindingResult.hasErrors());
   }
 
   @Test
@@ -62,7 +82,7 @@ public class DiaryTest {
     validator.validate(diary, bindingResult);
     // Asert
     assertEquals("userId", bindingResult.getFieldError().getField());
-    assertEquals("0 以上の値にしてください", bindingResult.getFieldError().getDefaultMessage());
+    assertEquals("{0}は0以上の値にしてください", bindingResult.getFieldError().getDefaultMessage());
   }
   
   @Test

--- a/backend/application-core/src/test/java/com/memoblend/applicationcore/diary/DiaryTest.java
+++ b/backend/application-core/src/test/java/com/memoblend/applicationcore/diary/DiaryTest.java
@@ -1,4 +1,3 @@
-
 package com.memoblend.applicationcore.diary;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -19,7 +18,7 @@ import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
  */
 @ExtendWith(SpringExtension.class)
 public class DiaryTest {
-  
+
   private Diary diary;
   private BindingResult bindingResult;
   private Validator validator;
@@ -52,7 +51,6 @@ public class DiaryTest {
   }
 
   @Test
-  @SuppressWarnings("null")
   public void testIdIsNull_異常系_IDが負の数() {
     // Arrange
     diary.setId(-1L);
@@ -74,7 +72,6 @@ public class DiaryTest {
   }
 
   @Test
-  @SuppressWarnings("null")
   public void testUserIdIsNull_異常系_userIdが負の数() {
     // Arrange
     diary.setUserId(-1L);
@@ -84,9 +81,8 @@ public class DiaryTest {
     assertEquals("userId", bindingResult.getFieldError().getField());
     assertEquals("{0}は0以上の値にしてください", bindingResult.getFieldError().getDefaultMessage());
   }
-  
+
   @Test
-  @SuppressWarnings("null")
   public void testTitleIsNull_異常系_titleがnull() {
     // Arrange
     diary.setTitle(null);
@@ -98,7 +94,6 @@ public class DiaryTest {
   }
 
   @Test
-  @SuppressWarnings("null")
   public void testTitleIsBlank_異常系_titleが空白() {
     // Arrange
     diary.setTitle(" ");
@@ -110,7 +105,6 @@ public class DiaryTest {
   }
 
   @Test
-  @SuppressWarnings("null")
   public void testTitleIsTooShort_異常系_titleが0文字() {
     // Arrange
     diary.setTitle("");
@@ -122,7 +116,6 @@ public class DiaryTest {
   }
 
   @Test
-  @SuppressWarnings("null")
   public void testTitleIsTooLong_異常系_titleの文字数オーバー() {
     // Arrange
     diary.setTitle("a".repeat(999));
@@ -134,7 +127,6 @@ public class DiaryTest {
   }
 
   @Test
-  @SuppressWarnings("null")
   public void testContentIsNull_異常系_contentがnull() {
     // Arrange
     diary.setContent(null);
@@ -146,7 +138,6 @@ public class DiaryTest {
   }
 
   @Test
-  @SuppressWarnings("null")
   public void testContentIsBlank_異常系_contentが空白() {
     // Arrange
     diary.setContent(" ");
@@ -158,7 +149,6 @@ public class DiaryTest {
   }
 
   @Test
-  @SuppressWarnings("null")
   public void testContentIsTooShort_異常系_contentが0文字() {
     // Arrange
     diary.setContent("");
@@ -170,7 +160,6 @@ public class DiaryTest {
   }
 
   @Test
-  @SuppressWarnings("null")
   public void testDateIsNull_異常系_日付がnull() {
     // Arrange
     diary.setDate(null);

--- a/backend/application-core/src/test/java/com/memoblend/applicationcore/diary/DiaryTest.java
+++ b/backend/application-core/src/test/java/com/memoblend/applicationcore/diary/DiaryTest.java
@@ -1,0 +1,176 @@
+
+package com.memoblend.applicationcore.diary;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.time.LocalDate;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.autoconfigure.context.MessageSourceAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.validation.BindException;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.Validator;
+import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
+/**
+ * 日記のドメインモデルのテストクラスです。
+ */
+@ExtendWith(SpringExtension.class)
+//@SpringBootTest
+public class DiaryTest {
+  
+  //@Autowired
+  Validator validator;
+
+  private Diary diary = new Diary(1L, 1L, "testTitle", "testContent", LocalDate.of(2025, 1, 1));
+  private BindingResult bindingResult = new BindException(diary, "Diary");
+
+
+  @BeforeEach
+  public void setUp() {
+    LocalValidatorFactoryBean factory = new LocalValidatorFactoryBean();
+    factory.afterPropertiesSet(); // 必須
+    this.validator = factory;
+    diary.setId(1L);
+    diary.setUserId(1L);
+    diary.setTitle("testTitle");
+    diary.setContent("testContent");
+    diary.setDate(LocalDate.of(2025, 1, 1));
+  }
+
+  @Test
+  public void testNoError_正常系_日記を作成できた場合はtrueを返す() {
+    // Act
+    validator.validate(diary, bindingResult);
+    // Assert
+    assertTrue(!bindingResult.hasErrors());
+  }
+
+  // @SuppressWarnings("null")
+  // @Test
+  // public void testIdIsNull_異常系_IDがnull() {
+  //   // Arrange
+  //   // diary = new Diary(0L, 1L, "testTitle", "testContent", LocalDate.now());
+  //   diary.setId((Long) null);
+  //   // Act
+  //   validator.validate(diary, bindingResult);
+  //   // Assert
+  //   assertEquals("id", bindingResult.getFieldError().getField());
+  //   assertEquals("must not be null", bindingResult.getFieldError().getDefaultMessage());
+  // }
+
+  // @Test
+  // void testUserIdIsNull_異常系_userIdがNull() {
+  //   // Arrange
+  //   diary = new Diary(1L, 0L, "testTitle", "testContent", LocalDate.now());
+  //   // Act
+  //   validator.validate(diary, bindingResult);
+  //   // Assert
+  //   assertNotNull(bindingResult.hasErrors());
+  //   assertEquals("userId", bindingResult.getFieldError().getField());
+  // }
+
+  // @Test
+  // public void testTitleIsNull_異常系_titleがnull() {
+  //   // Arrange
+  //   diary = new Diary(0L, 1L, null, "testContent", LocalDate.now());
+  //   // Act
+  //   validator.validate(diary, bindingResult);
+  //   // Assert
+  //   assertNotNull(bindingResult.hasErrors());
+  //   assertEquals("title", bindingResult.getFieldError().getField());
+  // }
+
+  // @Test
+  // public void testTitleIsBlank_異常系_titleが空白() {
+  //   // Arrange
+  //   diary = new Diary(0L, 1L, " ", "testContent", LocalDate.now());
+  //   // Act
+  //   validator.validate(diary, bindingResult);
+  //   // Assert
+  //   assertNotNull(bindingResult.hasErrors());
+  //   assertEquals("title", bindingResult.getFieldError().getField());
+  // }
+
+  // @Test
+  // public void testTitleIsTooShort_異常系_文章が0文字() {
+  //   // Arrange
+  //   diary = new Diary(0L, 1L, "", "testContent", LocalDate.now());
+  //   // Act
+  //   validator.validate(diary, bindingResult);
+  //   // Assert
+  //   assertNotNull(bindingResult.hasErrors());
+  //   assertEquals("title", bindingResult.getFieldError().getField());
+  //   assertEquals("titleは1～30文字の範囲で入力してください", bindingResult.getFieldError().getDefaultMessage());
+  // }
+
+  // @Test
+  // public void testTitleIsTooLong_異常系_titleの文字数オーバー() {
+  //   // Arrange
+  //   // diary.setTitle("a".repeat(999));
+  //   diary = new Diary(0L, 1L, "a".repeat(999), "testContent", LocalDate.now());
+  //   // Act
+  //   validator.validate(diary, bindingResult);
+  //   // Assert
+  //   assertNotNull(bindingResult.hasErrors());
+  //   assertEquals("title", bindingResult.getFieldError().getField());
+  //   assertEquals("titleは1～30文字の範囲で入力してください", bindingResult.getFieldError().getDefaultMessage());
+  // }
+
+  // @Test
+  // public void testContentIsNull_異常系_文章がnull() {
+  //   // Arrange
+  //   // diary.setContent(null);
+  //   diary = new Diary(0L, 1L, "testTitle", "null", LocalDate.now());
+  //   // Act
+  //   validator.validate(diary, bindingResult);
+  //   // Assert
+  //   assertNotNull(bindingResult.hasErrors());
+  //   assertEquals("content", bindingResult.getFieldError().getField());
+  //   assertEquals("must not be blank", bindingResult.getFieldError().getDefaultMessage());
+  // }
+
+  // @Test
+  // public void testContentIsBlank_異常系_文章が空白() {
+  //   // Arrange
+  //   // diary.setContent(" ");
+  //   diary = new Diary(0L, 1L, "testTitle", " ", LocalDate.now());
+  //   // Act
+  //   validator.validate(diary, bindingResult);
+  //   // Assert
+  //   assertNotNull(bindingResult.hasErrors());
+  //   assertEquals("content", bindingResult.getFieldError().getField());
+  //   assertEquals("must not be blank", bindingResult.getFieldError().getDefaultMessage());
+  // }
+
+  // @Test
+  // public void testContentIsTooShort_異常系_文章が0文字() {
+  //   // Arrange
+  //   // diary.setContent("");
+  //   diary = new Diary(0L, 1L, "testTitle", "", LocalDate.now());
+  //   // Act
+  //   validator.validate(diary, bindingResult);
+  //   // Assert
+  //   assertNotNull(bindingResult.hasErrors());
+  //   assertEquals("content", bindingResult.getFieldError().getField());
+  //   assertEquals("contentは1文字以上入力してください", bindingResult.getFieldError().getDefaultMessage());
+  // }
+
+  // @Test
+  // public void testDateIsNull_異常系_日付がnull() {
+  //   // Arrange
+  //   // diary.setDate(null);
+  //   diary = new Diary(0L, 1L, "testTitle", "testContent", null);
+  //   // Act
+  //   validator.validate(diary, bindingResult);
+  //   // Assert
+  //   assertNotNull(bindingResult.hasErrors());
+  //   assertEquals("date", bindingResult.getFieldError().getField());
+  // }
+}

--- a/backend/application-core/src/test/java/com/memoblend/applicationcore/diary/DiaryTest.java
+++ b/backend/application-core/src/test/java/com/memoblend/applicationcore/diary/DiaryTest.java
@@ -27,9 +27,7 @@ public class DiaryTest {
   void setUp() {
     this.diary = new Diary(1L, 1L, "testTitle", "testContent", LocalDate.of(2025, 1, 1));
     this.bindingResult = new BindException(diary, "Diary");
-    LocalValidatorFactoryBean factory = new LocalValidatorFactoryBean();
-    factory.afterPropertiesSet();
-    this.validator = factory;
+    setUpValidator();
   }
 
   @Test
@@ -51,7 +49,7 @@ public class DiaryTest {
   }
 
   @Test
-  public void testIdIsNull_異常系_IDが負の数() {
+  public void testIdIsNegative_異常系_IDが負の数() {
     // Arrange
     diary.setId(-1L);
     // Act
@@ -168,5 +166,11 @@ public class DiaryTest {
     // Assert
     assertEquals("date", bindingResult.getFieldError().getField());
     assertEquals("{0}は必須です", bindingResult.getFieldError().getDefaultMessage());
+  }
+
+  private void setUpValidator() {
+    LocalValidatorFactoryBean factory = new LocalValidatorFactoryBean();
+    factory.afterPropertiesSet();
+    this.validator = factory;
   }
 }

--- a/backend/application-core/src/test/java/com/memoblend/applicationcore/diary/DiaryTest.java
+++ b/backend/application-core/src/test/java/com/memoblend/applicationcore/diary/DiaryTest.java
@@ -1,47 +1,36 @@
 
 package com.memoblend.applicationcore.diary;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.time.LocalDate;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
-import org.springframework.boot.autoconfigure.context.MessageSourceAutoConfiguration;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.validation.BindException;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.Validator;
 import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
+
 /**
  * 日記のドメインモデルのテストクラスです。
  */
 @ExtendWith(SpringExtension.class)
-//@SpringBootTest
 public class DiaryTest {
   
-  //@Autowired
-  Validator validator;
-
-  private Diary diary = new Diary(1L, 1L, "testTitle", "testContent", LocalDate.of(2025, 1, 1));
-  private BindingResult bindingResult = new BindException(diary, "Diary");
-
+  private Diary diary;
+  private BindingResult bindingResult;
+  private Validator validator;
 
   @BeforeEach
-  public void setUp() {
+  void setUp() {
+    this.diary = new Diary(1L, 1L, "testTitle", "testContent", LocalDate.of(2025, 1, 1));
+    this.bindingResult = new BindException(diary, "Diary");
     LocalValidatorFactoryBean factory = new LocalValidatorFactoryBean();
-    factory.afterPropertiesSet(); // 必須
+    factory.afterPropertiesSet();
     this.validator = factory;
-    diary.setId(1L);
-    diary.setUserId(1L);
-    diary.setTitle("testTitle");
-    diary.setContent("testContent");
-    diary.setDate(LocalDate.of(2025, 1, 1));
   }
 
   @Test
@@ -52,125 +41,123 @@ public class DiaryTest {
     assertTrue(!bindingResult.hasErrors());
   }
 
-  // @SuppressWarnings("null")
-  // @Test
-  // public void testIdIsNull_異常系_IDがnull() {
-  //   // Arrange
-  //   // diary = new Diary(0L, 1L, "testTitle", "testContent", LocalDate.now());
-  //   diary.setId((Long) null);
-  //   // Act
-  //   validator.validate(diary, bindingResult);
-  //   // Assert
-  //   assertEquals("id", bindingResult.getFieldError().getField());
-  //   assertEquals("must not be null", bindingResult.getFieldError().getDefaultMessage());
-  // }
+  @Test
+  @SuppressWarnings("null")
+  public void testIdIsNull_異常系_IDが負の数() {
+    // Arrange
+    diary.setId(-1L);
+    // Act
+    validator.validate(diary, bindingResult);
+    // Assert
+    assertEquals("id", bindingResult.getFieldError().getField());
+    assertEquals("0 以上の値にしてください", bindingResult.getFieldError().getDefaultMessage());
+  }
 
-  // @Test
-  // void testUserIdIsNull_異常系_userIdがNull() {
-  //   // Arrange
-  //   diary = new Diary(1L, 0L, "testTitle", "testContent", LocalDate.now());
-  //   // Act
-  //   validator.validate(diary, bindingResult);
-  //   // Assert
-  //   assertNotNull(bindingResult.hasErrors());
-  //   assertEquals("userId", bindingResult.getFieldError().getField());
-  // }
+  @Test
+  @SuppressWarnings("null")
+  public void testUserIdIsNull_異常系_userIdが負の数() {
+    // Arrange
+    diary.setUserId(-1L);
+    // Act
+    validator.validate(diary, bindingResult);
+    // Asert
+    assertEquals("userId", bindingResult.getFieldError().getField());
+    assertEquals("0 以上の値にしてください", bindingResult.getFieldError().getDefaultMessage());
+  }
+  
+  @Test
+  @SuppressWarnings("null")
+  public void testTitleIsNull_異常系_titleがnull() {
+    // Arrange
+    diary.setTitle(null);
+    // Act
+    validator.validate(diary, bindingResult);
+    // Assert
+    assertEquals("title", bindingResult.getFieldError().getField());
+    assertEquals("{0}は1～30文字の範囲で入力してください", bindingResult.getFieldError().getDefaultMessage());
+  }
 
-  // @Test
-  // public void testTitleIsNull_異常系_titleがnull() {
-  //   // Arrange
-  //   diary = new Diary(0L, 1L, null, "testContent", LocalDate.now());
-  //   // Act
-  //   validator.validate(diary, bindingResult);
-  //   // Assert
-  //   assertNotNull(bindingResult.hasErrors());
-  //   assertEquals("title", bindingResult.getFieldError().getField());
-  // }
+  @Test
+  @SuppressWarnings("null")
+  public void testTitleIsBlank_異常系_titleが空白() {
+    // Arrange
+    diary.setTitle(" ");
+    // Act
+    validator.validate(diary, bindingResult);
+    // Assert
+    assertEquals("title", bindingResult.getFieldError().getField());
+    assertEquals("{0}は1～30文字の範囲で入力してください", bindingResult.getFieldError().getDefaultMessage());
+  }
 
-  // @Test
-  // public void testTitleIsBlank_異常系_titleが空白() {
-  //   // Arrange
-  //   diary = new Diary(0L, 1L, " ", "testContent", LocalDate.now());
-  //   // Act
-  //   validator.validate(diary, bindingResult);
-  //   // Assert
-  //   assertNotNull(bindingResult.hasErrors());
-  //   assertEquals("title", bindingResult.getFieldError().getField());
-  // }
+  @Test
+  @SuppressWarnings("null")
+  public void testTitleIsTooShort_異常系_titleが0文字() {
+    // Arrange
+    diary.setTitle("");
+    // Act
+    validator.validate(diary, bindingResult);
+    // Assert
+    assertEquals("title", bindingResult.getFieldError().getField());
+    assertEquals("{0}は1～30文字の範囲で入力してください", bindingResult.getFieldError().getDefaultMessage());
+  }
 
-  // @Test
-  // public void testTitleIsTooShort_異常系_文章が0文字() {
-  //   // Arrange
-  //   diary = new Diary(0L, 1L, "", "testContent", LocalDate.now());
-  //   // Act
-  //   validator.validate(diary, bindingResult);
-  //   // Assert
-  //   assertNotNull(bindingResult.hasErrors());
-  //   assertEquals("title", bindingResult.getFieldError().getField());
-  //   assertEquals("titleは1～30文字の範囲で入力してください", bindingResult.getFieldError().getDefaultMessage());
-  // }
+  @Test
+  @SuppressWarnings("null")
+  public void testTitleIsTooLong_異常系_titleの文字数オーバー() {
+    // Arrange
+    diary.setTitle("a".repeat(999));
+    // Act
+    validator.validate(diary, bindingResult);
+    // Assert
+    assertEquals("title", bindingResult.getFieldError().getField());
+    assertEquals("{0}は1～30文字の範囲で入力してください", bindingResult.getFieldError().getDefaultMessage());
+  }
 
-  // @Test
-  // public void testTitleIsTooLong_異常系_titleの文字数オーバー() {
-  //   // Arrange
-  //   // diary.setTitle("a".repeat(999));
-  //   diary = new Diary(0L, 1L, "a".repeat(999), "testContent", LocalDate.now());
-  //   // Act
-  //   validator.validate(diary, bindingResult);
-  //   // Assert
-  //   assertNotNull(bindingResult.hasErrors());
-  //   assertEquals("title", bindingResult.getFieldError().getField());
-  //   assertEquals("titleは1～30文字の範囲で入力してください", bindingResult.getFieldError().getDefaultMessage());
-  // }
+  @Test
+  @SuppressWarnings("null")
+  public void testContentIsNull_異常系_contentがnull() {
+    // Arrange
+    diary.setContent(null);
+    // Act
+    validator.validate(diary, bindingResult);
+    // Assert
+    assertEquals("content", bindingResult.getFieldError().getField());
+    assertEquals("{0}は1文字以上入力してください", bindingResult.getFieldError().getDefaultMessage());
+  }
 
-  // @Test
-  // public void testContentIsNull_異常系_文章がnull() {
-  //   // Arrange
-  //   // diary.setContent(null);
-  //   diary = new Diary(0L, 1L, "testTitle", "null", LocalDate.now());
-  //   // Act
-  //   validator.validate(diary, bindingResult);
-  //   // Assert
-  //   assertNotNull(bindingResult.hasErrors());
-  //   assertEquals("content", bindingResult.getFieldError().getField());
-  //   assertEquals("must not be blank", bindingResult.getFieldError().getDefaultMessage());
-  // }
+  @Test
+  @SuppressWarnings("null")
+  public void testContentIsBlank_異常系_contentが空白() {
+    // Arrange
+    diary.setContent(" ");
+    // Act
+    validator.validate(diary, bindingResult);
+    // Assert
+    assertEquals("content", bindingResult.getFieldError().getField());
+    assertEquals("{0}は1文字以上入力してください", bindingResult.getFieldError().getDefaultMessage());
+  }
 
-  // @Test
-  // public void testContentIsBlank_異常系_文章が空白() {
-  //   // Arrange
-  //   // diary.setContent(" ");
-  //   diary = new Diary(0L, 1L, "testTitle", " ", LocalDate.now());
-  //   // Act
-  //   validator.validate(diary, bindingResult);
-  //   // Assert
-  //   assertNotNull(bindingResult.hasErrors());
-  //   assertEquals("content", bindingResult.getFieldError().getField());
-  //   assertEquals("must not be blank", bindingResult.getFieldError().getDefaultMessage());
-  // }
+  @Test
+  @SuppressWarnings("null")
+  public void testContentIsTooShort_異常系_contentが0文字() {
+    // Arrange
+    diary.setContent("");
+    // Act
+    validator.validate(diary, bindingResult);
+    // Assert
+    assertEquals("content", bindingResult.getFieldError().getField());
+    assertEquals("{0}は1文字以上入力してください", bindingResult.getFieldError().getDefaultMessage());
+  }
 
-  // @Test
-  // public void testContentIsTooShort_異常系_文章が0文字() {
-  //   // Arrange
-  //   // diary.setContent("");
-  //   diary = new Diary(0L, 1L, "testTitle", "", LocalDate.now());
-  //   // Act
-  //   validator.validate(diary, bindingResult);
-  //   // Assert
-  //   assertNotNull(bindingResult.hasErrors());
-  //   assertEquals("content", bindingResult.getFieldError().getField());
-  //   assertEquals("contentは1文字以上入力してください", bindingResult.getFieldError().getDefaultMessage());
-  // }
-
-  // @Test
-  // public void testDateIsNull_異常系_日付がnull() {
-  //   // Arrange
-  //   // diary.setDate(null);
-  //   diary = new Diary(0L, 1L, "testTitle", "testContent", null);
-  //   // Act
-  //   validator.validate(diary, bindingResult);
-  //   // Assert
-  //   assertNotNull(bindingResult.hasErrors());
-  //   assertEquals("date", bindingResult.getFieldError().getField());
-  // }
+  @Test
+  @SuppressWarnings("null")
+  public void testDateIsNull_異常系_日付がnull() {
+    // Arrange
+    diary.setDate(null);
+    // Act
+    validator.validate(diary, bindingResult);
+    // Assert
+    assertEquals("date", bindingResult.getFieldError().getField());
+    assertEquals("{0}は必須です", bindingResult.getFieldError().getDefaultMessage());
+  }
 }


### PR DESCRIPTION
## 本プルリクエストで実施したこと
- 日記ドメインの単体テスト(DiaryTest.java)の実装
  - JUnit4を用いている参考ページ (https://qiita.com/kenduck/items/da6f5f30d05f7abc1da4) を元にJUnit5で書きなおしました。BindingResult を用いましたが、他に良い方法があればそちらで書き直すので指摘してください。

- 日記ドメイン(Diary.java)の修正
  - @NotBklankはnullチェックも含んでいるため、@NotNullを削除しました。
    ![image](https://github.com/user-attachments/assets/6cea03ba-83b3-490d-981b-d6e5e0a386ce)

  - エラー時のデフォルトメッセージは実行環境により異なる(日本語や英語などで表示される)ため、下図のようにあらかじめmessageを指定することとしました。（指定しないと単体テストで確認が困難なため指定しました。）
    ![image](https://github.com/user-attachments/assets/f94fda46-ad80-49ed-8582-95cc29cbfc81)


## 本プルリクエストで実施していないこと
- 未来の日付を入力した際の単体テスト

## 関連Issue、参考ページ
- https://qiita.com/kenduck/items/da6f5f30d05f7abc1da4