### PR TITLE
ユーザーの論理削除の単体テスト実装

### DIFF
--- a/backend/api-docs/web/api-specification.json
+++ b/backend/api-docs/web/api-specification.json
@@ -458,6 +458,9 @@
       "PutUserRequest": {
         "type": "object",
         "properties": {
+          "deleted": {
+            "type": "boolean"
+          },
           "id": {
             "type": "integer",
             "format": "int64"

--- a/backend/application-core/src/main/java/com/memoblend/applicationcore/user/User.java
+++ b/backend/application-core/src/main/java/com/memoblend/applicationcore/user/User.java
@@ -21,4 +21,7 @@ public class User {
   @NotBlank(message = "{0}は1～15文字の範囲で入力してください")
   @Size(min = 1, max = 15, message = "{0}は1～15文字の範囲で入力してください")
   private String name;
+
+  @NotNull(message = "{0}は必須です") 
+  private boolean isDeleted;
 }

--- a/backend/application-core/src/main/java/com/memoblend/applicationcore/user/UserDomainService.java
+++ b/backend/application-core/src/main/java/com/memoblend/applicationcore/user/UserDomainService.java
@@ -20,6 +20,10 @@ public class UserDomainService {
    * @return ユーザーが存在する場合は true 、存在しない場合は false 。
    */
   public boolean isExistUser(long id) {
-    return userRepository.findById(id) != null;
+    if (userRepository.findById(id) == null
+        || userRepository.findById(id).isDeleted()) {
+      return false;
+    }
+    return true;
   }
 }

--- a/backend/application-core/src/test/java/com/memoblend/applicationcore/applicationservice/UserApplicationServiceTest.java
+++ b/backend/application-core/src/test/java/com/memoblend/applicationcore/applicationservice/UserApplicationServiceTest.java
@@ -203,7 +203,7 @@ public class UserApplicationServiceTest {
 
   private User createUser(String name) {
     long id = 1;
-    User user = new User(id, name);
+    User user = new User(id, name, false);
     return user;
   }
 

--- a/backend/application-core/src/test/java/com/memoblend/applicationcore/user/UserDomainServiceTest.java
+++ b/backend/application-core/src/test/java/com/memoblend/applicationcore/user/UserDomainServiceTest.java
@@ -51,7 +51,7 @@ public class UserDomainServiceTest {
 
   private User createUser(String name) {
     long id = 1;
-    User user = new User(id, name);
+    User user = new User(id, name, false);
     return user;
   }
 }

--- a/backend/application-core/src/test/java/com/memoblend/applicationcore/user/UserTest.java
+++ b/backend/application-core/src/test/java/com/memoblend/applicationcore/user/UserTest.java
@@ -102,6 +102,26 @@ public class UserTest {
     assertEquals("{0}は1～15文字の範囲で入力してください", bindingResult.getFieldError().getDefaultMessage());
   }
 
+  @Test
+  public void testIsDeletedIsFalse_正常系_isDeletedがfalse() {
+    // Arrange
+    user.setDeleted(false);
+    // Act
+    validator.validate(user, bindingResult);
+    // Assert
+    assertTrue(!bindingResult.hasErrors());
+  }
+
+  @Test
+  public void testIsDeletedIsTrue_正常系_isDeletedがtrue() {
+    // Arrange
+    user.setDeleted(true);
+    // Act
+    validator.validate(user, bindingResult);
+    // Assert
+    assertTrue(!bindingResult.hasErrors());
+  }
+
   private void setUpValidator() {
     LocalValidatorFactoryBean factory = new LocalValidatorFactoryBean();
     factory.afterPropertiesSet();

--- a/backend/application-core/src/test/java/com/memoblend/applicationcore/user/UserTest.java
+++ b/backend/application-core/src/test/java/com/memoblend/applicationcore/user/UserTest.java
@@ -24,7 +24,7 @@ public class UserTest {
 
   @BeforeEach
   void setUp() {
-    this.user = new User(1L, "testName");
+    this.user = new User(1L, "testName", false);
     this.bindingResult = new BindException(user, "User");
     setUpValidator();
   }

--- a/backend/infrastructure/src/main/java/com/memoblend/infrastructure/repository/mapper/UserMapper.xml
+++ b/backend/infrastructure/src/main/java/com/memoblend/infrastructure/repository/mapper/UserMapper.xml
@@ -15,8 +15,10 @@
 		VALUES (#{name})
 	</insert>
 
-    <delete id="delete" parameterType="long">
-		DELETE FROM users WHERE id = #{id}
+  <delete id="delete" parameterType="long">
+		UPDATE users
+		SET is_deleted = true
+		WHERE id = #{id}
 	</delete>
 
 	<update id="update" parameterType="com.memoblend.applicationcore.user.User">

--- a/backend/infrastructure/src/main/resources/data.sql
+++ b/backend/infrastructure/src/main/resources/data.sql
@@ -1,15 +1,15 @@
 -- Insert 10 dummy records into `users`
-INSERT INTO users (name) VALUES
-('Alice'),
-('Bob'),
-('Charlie'),
-('Diana'),
-('Eve'),
-('Frank'),
-('Grace'),
-('Hank'),
-('Ivy'),
-('Jack');
+INSERT INTO users (name, is_deleted) VALUES
+('Alice', false),
+('Bob', false),
+('Charlie', false),
+('Diana', false),
+('Eve', false),
+('Frank', false),
+('Grace', false),
+('Hank', false),
+('Ivy', false),
+('Jack', false);
 
 -- Insert 10 dummy records into `diaries`
 INSERT INTO diaries (user_id, title, content, date) VALUES

--- a/backend/infrastructure/src/main/resources/schema.sql
+++ b/backend/infrastructure/src/main/resources/schema.sql
@@ -2,7 +2,8 @@ DROP TABLE IF EXISTS users CASCADE;
 CREATE TABLE users
 (
   id BIGSERIAL NOT NULL PRIMARY KEY, -- primary key column
-  name VARCHAR(64) NOT NULL
+  name VARCHAR(64) NOT NULL,
+  is_deleted BOOLEAN NOT NULL DEFAULT FALSE
 );
 
 -- Drop and create the `diaries` table

--- a/backend/web/src/main/java/com/memoblend/web/controller/dto/user/GetUserResponse.java
+++ b/backend/web/src/main/java/com/memoblend/web/controller/dto/user/GetUserResponse.java
@@ -11,4 +11,5 @@ import lombok.Data;
 public class GetUserResponse {
   private long id;
   private String name;
+  private boolean isDeleted;
 }

--- a/backend/web/src/main/java/com/memoblend/web/controller/dto/user/PutUserRequest.java
+++ b/backend/web/src/main/java/com/memoblend/web/controller/dto/user/PutUserRequest.java
@@ -11,4 +11,5 @@ import lombok.Data;
 public class PutUserRequest {
   private long id;
   private String name;
+  private boolean isDeleted;
 }

--- a/backend/web/src/main/java/com/memoblend/web/controller/mapper/user/GetUserReponseMapper.java
+++ b/backend/web/src/main/java/com/memoblend/web/controller/mapper/user/GetUserReponseMapper.java
@@ -17,7 +17,8 @@ public class GetUserReponseMapper {
   public static GetUserResponse convert(User user) {
     GetUserResponse response = new GetUserResponse(
         user.getId(),
-        user.getName());
+        user.getName(),
+        false);
     return response;
   }
 }

--- a/backend/web/src/main/java/com/memoblend/web/controller/mapper/user/PostUserRequestMapper.java
+++ b/backend/web/src/main/java/com/memoblend/web/controller/mapper/user/PostUserRequestMapper.java
@@ -17,7 +17,8 @@ public class PostUserRequestMapper {
   public static User convert(PostUserRequest request) {
     User user = new User(
         0,
-        request.getName());
+        request.getName(),
+        false);
     return user;
   }
 }

--- a/backend/web/src/main/java/com/memoblend/web/controller/mapper/user/PutUserRequestMapper.java
+++ b/backend/web/src/main/java/com/memoblend/web/controller/mapper/user/PutUserRequestMapper.java
@@ -17,7 +17,8 @@ public class PutUserRequestMapper {
   public static User convert(PutUserRequest request) {
     User user = new User(
         request.getId(),
-        request.getName());
+        request.getName(),
+        false);
     return user;
   }
 }


### PR DESCRIPTION
## 本プルリクエストで実施したこと
- ユーザーの論理削除のチェックをUserTest.javaに追記。
- Nullチェックはboolean型がnullに非対応のため実装しませんでした（stringと同じ状態です）。

## 本プルリクエストで実施していないこと
- なし。

## 関連Issue、参考ページ
- #223 