### PR TITLE
pythonバージョン指定方法変更

### DIFF
--- a/analysisapi/Pipfile
+++ b/analysisapi/Pipfile
@@ -9,5 +9,4 @@ httpx = "*"
 fastapi = {extras = ["all"], version = "*"}
 
 [requires]
-python_version = "3.13"
-python_full_version = "3.13.1"
+python_version = "3"

--- a/analysisapi/Pipfile
+++ b/analysisapi/Pipfile
@@ -4,9 +4,9 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-uvicorn = "*"
-httpx = "*"
-fastapi = {extras = ["all"], version = "*"}
+uvicorn = "0.34.0"
+httpx = "0.28.1"
+fastapi = {extras = ["all"], version = "0.115.11"}
 
 [requires]
 python_version = "3"

--- a/analysisapi/Pipfile.lock
+++ b/analysisapi/Pipfile.lock
@@ -1,12 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "4fd9b8c98337ecf169f97f09ac9bc092d4efa31d3e7aae3dee1d556bcb005cdb"
+            "sha256": "6a22dc4e2e7bb2783c459a83f65732e342c4deac22a8dc2fc864877df1b33477"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_full_version": "3.13.1",
-            "python_version": "3.13"
+            "python_version": "3"
         },
         "sources": [
             {
@@ -27,11 +26,11 @@
         },
         "anyio": {
             "hashes": [
-                "sha256:1d9fe889df5212298c0c0723fa20479d1b94883a2df44bd3897aa91083316f7a",
-                "sha256:b5011f270ab5eb0abf13385f851315585cc37ef330dd88e27ec3d34d651fd47a"
+                "sha256:673c0c244e15788651a4ff38710fea9675823028a6f08a5eda409e0c9840a028",
+                "sha256:9f76d541cad6e36af7beb62e978876f3b41e3e04f2c1fbf0884604c0a9c4d93c"
             ],
             "markers": "python_version >= '3.9'",
-            "version": "==4.8.0"
+            "version": "==4.9.0"
         },
         "certifi": {
             "hashes": [
@@ -477,11 +476,11 @@
         },
         "pydantic-extra-types": {
             "hashes": [
-                "sha256:934d59ab7a02ff788759c3a97bc896f5cfdc91e62e4f88ea4669067a73f14b98",
-                "sha256:9eccd55a2b7935cea25f0a67f6ff763d55d80c41d86b887d88915412ccf5b7fa"
+                "sha256:dcc0a7b90ac9ef1b58876c9b8fdede17fbdde15420de9d571a9fccde2ae175bb",
+                "sha256:e8b372752b49019cd8249cc192c62a820d8019f5382a8789d0f887338a59c0f3"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==2.10.2"
+            "version": "==2.10.3"
         },
         "pydantic-settings": {
             "hashes": [
@@ -879,47 +878,5 @@
             "version": "==15.0.1"
         }
     },
-    "develop": {
-        "colorama": {
-            "hashes": [
-                "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44",
-                "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"
-            ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6'",
-            "version": "==0.4.6"
-        },
-        "iniconfig": {
-            "hashes": [
-                "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3",
-                "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374"
-            ],
-            "markers": "python_version >= '3.7'",
-            "version": "==2.0.0"
-        },
-        "packaging": {
-            "hashes": [
-                "sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759",
-                "sha256:c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f"
-            ],
-            "markers": "python_version >= '3.8'",
-            "version": "==24.2"
-        },
-        "pluggy": {
-            "hashes": [
-                "sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1",
-                "sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669"
-            ],
-            "markers": "python_version >= '3.8'",
-            "version": "==1.5.0"
-        },
-        "pytest": {
-            "hashes": [
-                "sha256:c69214aa47deac29fad6c2a4f590b9c4a9fdb16a403176fe154b79c0b4d4d820",
-                "sha256:f4efe70cc14e511565ac476b57c279e12a855b11f48f212af1080ef2263d3845"
-            ],
-            "index": "pypi",
-            "markers": "python_version >= '3.8'",
-            "version": "==8.3.5"
-        }
-    }
+    "develop": {}
 }

--- a/analysisapi/Pipfile.lock
+++ b/analysisapi/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "6a22dc4e2e7bb2783c459a83f65732e342c4deac22a8dc2fc864877df1b33477"
+            "sha256": "50147808c338cb31b72438d2a6bb00a9aab6fb065f78c1f073068b8f32a14cff"
         },
         "pipfile-spec": 6,
         "requires": {


### PR DESCRIPTION
## 本プルリクエストで実施したこと
- pipfileのpythonバージョン指定を3.Xに変更。
- pythonのバージョン管理は各ユーザーの方法にまかせる。

## 本プルリクエストで実施していないこと
- なし

## 関連Issue、参考ページ
- #276 
- #295 