### PR TITLE
日記の値オブジェクトを実装

### DIFF
--- a/backend/api-docs/web/api-specification.json
+++ b/backend/api-docs/web/api-specification.json
@@ -361,7 +361,15 @@
             "type": "integer",
             "format": "int64"
           }
-        }
+        },
+        "required": [
+          "content",
+          "createdDate",
+          "id",
+          "isDeleted",
+          "title",
+          "userId"
+        ]
       },
       "GetDiariesResponse": {
         "type": "object",

--- a/backend/api-docs/web/api-specification.json
+++ b/backend/api-docs/web/api-specification.json
@@ -341,38 +341,27 @@
         "type": "object",
         "properties": {
           "content": {
-            "type": "string",
-            "maxLength": 2147483647,
-            "minLength": 1
+            "type": "string"
           },
-          "date": {
+          "createdDate": {
             "type": "string",
             "format": "date"
-          },
-          "deleted": {
-            "type": "boolean"
           },
           "id": {
             "type": "integer",
             "format": "int64"
           },
+          "isDeleted": {
+            "type": "boolean"
+          },
           "title": {
-            "type": "string",
-            "maxLength": 30,
-            "minLength": 1
+            "type": "string"
           },
           "userId": {
             "type": "integer",
             "format": "int64"
           }
-        },
-        "required": [
-          "content",
-          "date",
-          "id",
-          "title",
-          "userId"
-        ]
+        }
       },
       "GetDiariesResponse": {
         "type": "object",
@@ -391,7 +380,7 @@
           "content": {
             "type": "string"
           },
-          "date": {
+          "createdDate": {
             "type": "string",
             "format": "date"
           },
@@ -414,7 +403,7 @@
           "content": {
             "type": "string"
           },
-          "date": {
+          "createdDate": {
             "type": "string",
             "format": "date"
           },
@@ -441,7 +430,7 @@
           "content": {
             "type": "string"
           },
-          "date": {
+          "createdDate": {
             "type": "string",
             "format": "date"
           },

--- a/backend/application-core/src/main/java/com/memoblend/applicationcore/applicationservice/DiaryApplicationService.java
+++ b/backend/application-core/src/main/java/com/memoblend/applicationcore/applicationservice/DiaryApplicationService.java
@@ -79,9 +79,10 @@ public class DiaryApplicationService {
    * @throws PermissionDeniedException 認可が拒否された場合。
    */
   public Diary addDiary(Diary diary) throws PermissionDeniedException {
-    final LocalDate date = diary.getCreatedDate();
+    final LocalDate createdDate = diary.getCreatedDate();
     apLog.info(messages.getMessage(MessageIdConstants.D_DIARY_ADD_DIARY,
-        new Object[] { date.getYear(), date.getMonthValue(), date.getDayOfMonth() }, Locale.getDefault()));
+        new Object[] { createdDate.getYear(), createdDate.getMonthValue(), createdDate.getDayOfMonth() },
+        Locale.getDefault()));
     if (!userStore.isInRole(UserRoleConstants.USER)) {
       throw new PermissionDeniedException("addDiary");
     }

--- a/backend/application-core/src/main/java/com/memoblend/applicationcore/applicationservice/DiaryApplicationService.java
+++ b/backend/application-core/src/main/java/com/memoblend/applicationcore/applicationservice/DiaryApplicationService.java
@@ -79,7 +79,7 @@ public class DiaryApplicationService {
    * @throws PermissionDeniedException 認可が拒否された場合。
    */
   public Diary addDiary(Diary diary) throws PermissionDeniedException {
-    final LocalDate date = diary.getDate();
+    final LocalDate date = diary.getCreatedDate();
     apLog.info(messages.getMessage(MessageIdConstants.D_DIARY_ADD_DIARY,
         new Object[] { date.getYear(), date.getMonthValue(), date.getDayOfMonth() }, Locale.getDefault()));
     if (!userStore.isInRole(UserRoleConstants.USER)) {

--- a/backend/application-core/src/main/java/com/memoblend/applicationcore/diary/Diary.java
+++ b/backend/application-core/src/main/java/com/memoblend/applicationcore/diary/Diary.java
@@ -1,7 +1,6 @@
 package com.memoblend.applicationcore.diary;
 
 import java.time.LocalDate;
-
 import com.memoblend.applicationcore.diary.valueobject.Content;
 import com.memoblend.applicationcore.diary.valueobject.CreatedDate;
 import com.memoblend.applicationcore.diary.valueobject.Id;

--- a/backend/application-core/src/main/java/com/memoblend/applicationcore/diary/Diary.java
+++ b/backend/application-core/src/main/java/com/memoblend/applicationcore/diary/Diary.java
@@ -8,16 +8,24 @@ import com.memoblend.applicationcore.diary.valueobject.IsDeleted;
 import com.memoblend.applicationcore.diary.valueobject.Title;
 import com.memoblend.applicationcore.diary.valueobject.UserId;
 
+import io.micrometer.common.lang.NonNull;
+
 /**
  * 日記のドメインモデルです。
  */
 public class Diary {
 
+  @NonNull
   private Id id;
+  @NonNull
   private UserId userId;
+  @NonNull
   private Title title;
+  @NonNull
   private Content content;
+  @NonNull
   private CreatedDate createdDate;
+  @NonNull
   private IsDeleted isDeleted;
 
   /**

--- a/backend/application-core/src/main/java/com/memoblend/applicationcore/diary/Diary.java
+++ b/backend/application-core/src/main/java/com/memoblend/applicationcore/diary/Diary.java
@@ -1,14 +1,13 @@
 package com.memoblend.applicationcore.diary;
 
 import java.time.LocalDate;
+import org.springframework.lang.NonNull;
 import com.memoblend.applicationcore.diary.valueobject.Content;
 import com.memoblend.applicationcore.diary.valueobject.CreatedDate;
 import com.memoblend.applicationcore.diary.valueobject.Id;
 import com.memoblend.applicationcore.diary.valueobject.IsDeleted;
 import com.memoblend.applicationcore.diary.valueobject.Title;
 import com.memoblend.applicationcore.diary.valueobject.UserId;
-
-import io.micrometer.common.lang.NonNull;
 
 /**
  * 日記のドメインモデルです。

--- a/backend/application-core/src/main/java/com/memoblend/applicationcore/diary/Diary.java
+++ b/backend/application-core/src/main/java/com/memoblend/applicationcore/diary/Diary.java
@@ -1,38 +1,150 @@
 package com.memoblend.applicationcore.diary;
 
 import java.time.LocalDate;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.PositiveOrZero;
-import jakarta.validation.constraints.Size;
-import lombok.AllArgsConstructor;
-import lombok.Data;
+
+import com.memoblend.applicationcore.diary.valueobject.Content;
+import com.memoblend.applicationcore.diary.valueobject.CreatedDate;
+import com.memoblend.applicationcore.diary.valueobject.Id;
+import com.memoblend.applicationcore.diary.valueobject.IsDeleted;
+import com.memoblend.applicationcore.diary.valueobject.Title;
+import com.memoblend.applicationcore.diary.valueobject.UserId;
 
 /**
  * 日記のドメインモデルです。
  */
-@Data
-@AllArgsConstructor
 public class Diary {
 
-  @NotNull(message = "{0}は必須です")
-  @PositiveOrZero(message = "{0}は0以上の値にしてください")
-  private long id;
+  private Id id;
+  private UserId userId;
+  private Title title;
+  private Content content;
+  private CreatedDate createdDate;
+  private IsDeleted isDeleted;
 
-  @NotNull(message = "{0}は必須です")
-  @PositiveOrZero(message = "{0}は0以上の値にしてください")
-  private long userId;
+  /**
+   * {@link Diary} クラスの新しいインスタンスを初期化します。
+   * 
+   * @param id          ID。
+   * @param userId      ユーザー ID。
+   * @param title       タイトル。
+   * @param content     内容。
+   * @param createdDate 作成日時。
+   * @param isDeleted   削除フラグ。
+   */
+  public Diary(long id, long userId, String title, String content, LocalDate createdDate, boolean isDeleted) {
+    this.id = new Id(id);
+    this.userId = new UserId(userId);
+    this.title = new Title(title);
+    this.content = new Content(content);
+    this.createdDate = new CreatedDate(createdDate);
+    this.isDeleted = new IsDeleted(isDeleted);
+  }
 
-  @NotBlank(message = "{0}は1～30文字の範囲で入力してください")
-  @Size(min = 1, max = 30, message = "{0}は1～30文字の範囲で入力してください")
-  private String title;
+  /**
+   * ID を取得します。
+   * 
+   * @return ID。
+   */
+  public long getId() {
+    return this.id.getValue();
+  }
 
-  @NotBlank(message = "{0}は1文字以上入力してください")
-  @Size(min = 1, message = "{0}は1文字以上入力してください")
-  private String content;
+  /**
+   * ユーザー ID を取得します。
+   * 
+   * @return ユーザー ID。
+   */
+  public long getUserId() {
+    return this.userId.getValue();
+  }
 
-  @NotNull(message = "{0}は必須です")
-  private LocalDate date;
+  /**
+   * タイトルを取得します。
+   * 
+   * @return タイトル。
+   */
+  public String getTitle() {
+    return this.title.getValue();
+  }
 
-  private boolean isDeleted;
+  /**
+   * 内容を取得します。
+   * 
+   * @return 内容。
+   */
+  public String getContent() {
+    return this.content.getValue();
+  }
+
+  /**
+   * 作成日時を取得します。
+   * 
+   * @return 作成日時。
+   */
+  public LocalDate getCreatedDate() {
+    return this.createdDate.getValue();
+  }
+
+  /**
+   * 削除フラグを取得します。
+   * 
+   * @return 削除フラグ。
+   */
+  public boolean getIsDeleted() {
+    return this.isDeleted.isValue();
+  }
+
+  /**
+   * ID を設定します。
+   * 
+   * @param id ID。
+   */
+  public void setId(long id) {
+    this.id = new Id(id);
+  }
+
+  /**
+   * ユーザー ID を設定します。
+   * 
+   * @param userId ユーザー ID。
+   */
+  public void setUserId(long userId) {
+    this.userId = new UserId(userId);
+  }
+
+  /**
+   * タイトルを設定します。
+   * 
+   * @param title タイトル。
+   */
+  public void setTitle(String title) {
+    this.title = new Title(title);
+  }
+
+  /**
+   * 内容を設定します。
+   * 
+   * @param content 内容。
+   */
+  public void setContent(String content) {
+    this.content = new Content(content);
+  }
+
+  /**
+   * 作成日時を設定します。
+   * 
+   * @param createdDate 作成日時。
+   */
+  public void setCreatedDate(LocalDate createdDate) {
+    this.createdDate = new CreatedDate(createdDate);
+  }
+
+  /**
+   * 削除フラグを設定します。
+   * 
+   * @param isDeleted 削除フラグ。
+   */
+  public void setIsDeleted(boolean isDeleted) {
+    this.isDeleted = new IsDeleted(isDeleted);
+  }
 }

--- a/backend/application-core/src/main/java/com/memoblend/applicationcore/diary/DiaryDomainService.java
+++ b/backend/application-core/src/main/java/com/memoblend/applicationcore/diary/DiaryDomainService.java
@@ -21,7 +21,7 @@ public class DiaryDomainService {
    */
   public boolean isExistDiary(long id) {
     Diary diary = diaryRepository.findById(id);
-    if (diary == null || diary.isDeleted()) {
+    if (diary == null || diary.getIsDeleted()) {
       return false;
     }
     return true;

--- a/backend/application-core/src/main/java/com/memoblend/applicationcore/diary/valueobject/Content.java
+++ b/backend/application-core/src/main/java/com/memoblend/applicationcore/diary/valueobject/Content.java
@@ -1,5 +1,26 @@
 package com.memoblend.applicationcore.diary.valueobject;
 
-public class Content {
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
 
+@Getter
+@EqualsAndHashCode
+public class Content {
+    private final String value;
+
+    /**
+     * {@link Content} クラスの新しいインスタンスを初期化します。
+     * 
+     * @param value コンテンツの値。
+     * @throws IllegalArgumentException コンテンツの値が null か指定の文字数範囲外の場合。
+     */
+    public Content(String value) {
+        if (value == null || value.isEmpty()) {
+            throw new IllegalArgumentException("{0} は {1} 文字以上入力してください");
+        }
+        if (value.length() < 1 || value.length() > 1000) {
+            throw new IllegalArgumentException("{0} は {1} ～ {2} 文字の範囲で入力してください");
+        }
+        this.value = value;
+    }
 }

--- a/backend/application-core/src/main/java/com/memoblend/applicationcore/diary/valueobject/Content.java
+++ b/backend/application-core/src/main/java/com/memoblend/applicationcore/diary/valueobject/Content.java
@@ -3,24 +3,27 @@ package com.memoblend.applicationcore.diary.valueobject;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
+/**
+ * コンテンツを表す値オブジェクト。
+ */
 @Getter
 @EqualsAndHashCode
 public class Content {
-    private final String value;
+  private final String value;
 
-    /**
-     * {@link Content} クラスの新しいインスタンスを初期化します。
-     * 
-     * @param value コンテンツの値。
-     * @throws IllegalArgumentException コンテンツの値が null か指定の文字数範囲外の場合。
-     */
-    public Content(String value) {
-        if (value == null || value.isEmpty()) {
-            throw new IllegalArgumentException("{0} は {1} 文字以上入力してください");
-        }
-        if (value.length() < 1 || value.length() > 1000) {
-            throw new IllegalArgumentException("{0} は {1} ～ {2} 文字の範囲で入力してください");
-        }
-        this.value = value;
+  /**
+   * {@link Content} クラスの新しいインスタンスを初期化します。
+   * 
+   * @param value コンテンツの値。
+   * @throws IllegalArgumentException コンテンツの値が null か指定の文字数範囲外の場合。
+   */
+  public Content(String value) {
+    if (value == null || value.isEmpty()) {
+      throw new IllegalArgumentException("{0} は {1} 文字以上入力してください");
     }
+    if (value.length() < 1 || value.length() > 1000) {
+      throw new IllegalArgumentException("{0} は {1} ～ {2} 文字の範囲で入力してください");
+    }
+    this.value = value;
+  }
 }

--- a/backend/application-core/src/main/java/com/memoblend/applicationcore/diary/valueobject/Content.java
+++ b/backend/application-core/src/main/java/com/memoblend/applicationcore/diary/valueobject/Content.java
@@ -1,0 +1,5 @@
+package com.memoblend.applicationcore.diary.valueobject;
+
+public class Content {
+
+}

--- a/backend/application-core/src/main/java/com/memoblend/applicationcore/diary/valueobject/Content.java
+++ b/backend/application-core/src/main/java/com/memoblend/applicationcore/diary/valueobject/Content.java
@@ -18,7 +18,7 @@ public class Content {
    * @throws IllegalArgumentException コンテンツの値が null か指定の文字数範囲外の場合。
    */
   public Content(String value) {
-    if (value == null || value.isEmpty()) {
+    if (value == null || value.isEmpty() || value.isBlank()) {
       throw new IllegalArgumentException("{0} は {1} 文字以上入力してください");
     }
     if (value.length() < 1 || value.length() > 1000) {

--- a/backend/application-core/src/main/java/com/memoblend/applicationcore/diary/valueobject/CreatedDate.java
+++ b/backend/application-core/src/main/java/com/memoblend/applicationcore/diary/valueobject/CreatedDate.java
@@ -1,0 +1,25 @@
+package com.memoblend.applicationcore.diary.valueobject;
+
+import java.time.LocalDate;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+@Getter
+@EqualsAndHashCode
+public class CreatedDate {
+    private final LocalDate value;
+
+    /**
+     * {@link CreatedDate} クラスの新しいインスタンスを初期化します。
+     * 
+     * @param value 作成日時の値。
+     * @throws IllegalArgumentException 作成日時の値が 0 未満の場合。
+     */
+    public CreatedDate(LocalDate value) {
+        if (value == null) {
+            throw new IllegalArgumentException("{0} は null にできません");
+        }
+        this.value = value;
+    }
+}

--- a/backend/application-core/src/main/java/com/memoblend/applicationcore/diary/valueobject/CreatedDate.java
+++ b/backend/application-core/src/main/java/com/memoblend/applicationcore/diary/valueobject/CreatedDate.java
@@ -1,25 +1,27 @@
 package com.memoblend.applicationcore.diary.valueobject;
 
 import java.time.LocalDate;
-
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
+/**
+ * 作成日時を表す値オブジェクト。
+ */
 @Getter
 @EqualsAndHashCode
 public class CreatedDate {
-    private final LocalDate value;
+  private final LocalDate value;
 
-    /**
-     * {@link CreatedDate} クラスの新しいインスタンスを初期化します。
-     * 
-     * @param value 作成日時の値。
-     * @throws IllegalArgumentException 作成日時の値が 0 未満の場合。
-     */
-    public CreatedDate(LocalDate value) {
-        if (value == null) {
-            throw new IllegalArgumentException("{0} は null にできません");
-        }
-        this.value = value;
+  /**
+   * {@link CreatedDate} クラスの新しいインスタンスを初期化します。
+   * 
+   * @param value 作成日時の値。
+   * @throws IllegalArgumentException 作成日時の値が null の場合。
+   */
+  public CreatedDate(LocalDate value) {
+    if (value == null) {
+      throw new IllegalArgumentException("{0} は必須です");
     }
+    this.value = value;
+  }
 }

--- a/backend/application-core/src/main/java/com/memoblend/applicationcore/diary/valueobject/Id.java
+++ b/backend/application-core/src/main/java/com/memoblend/applicationcore/diary/valueobject/Id.java
@@ -3,21 +3,24 @@ package com.memoblend.applicationcore.diary.valueobject;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
+/**
+ * ID を表す値オブジェクト。
+ */
 @Getter
 @EqualsAndHashCode
 public class Id {
-    private final long value;
+  private final long value;
 
-    /**
-     * {@link Id} クラスの新しいインスタンスを初期化します。
-     * 
-     * @param value ID の値。
-     * @throws IllegalArgumentException ID の値が 0 未満の場合。
-     */
-    public Id(long value) {
-        if (value < 0) {
-            throw new IllegalArgumentException("{0} は {1} 以上の値にしてください");
-        }
-        this.value = value;
+  /**
+   * {@link Id} クラスの新しいインスタンスを初期化します。
+   * 
+   * @param value ID の値。
+   * @throws IllegalArgumentException ID の値が 0 未満の場合。
+   */
+  public Id(long value) {
+    if (value < 0) {
+      throw new IllegalArgumentException("{0} は {1} 以上の値にしてください");
     }
+    this.value = value;
+  }
 }

--- a/backend/application-core/src/main/java/com/memoblend/applicationcore/diary/valueobject/Id.java
+++ b/backend/application-core/src/main/java/com/memoblend/applicationcore/diary/valueobject/Id.java
@@ -1,0 +1,5 @@
+package com.memoblend.applicationcore.diary.valueobject;
+
+public class Id {
+
+}

--- a/backend/application-core/src/main/java/com/memoblend/applicationcore/diary/valueobject/Id.java
+++ b/backend/application-core/src/main/java/com/memoblend/applicationcore/diary/valueobject/Id.java
@@ -1,5 +1,23 @@
 package com.memoblend.applicationcore.diary.valueobject;
 
-public class Id {
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
 
+@Getter
+@EqualsAndHashCode
+public class Id {
+    private final long value;
+
+    /**
+     * {@link Id} クラスの新しいインスタンスを初期化します。
+     * 
+     * @param value ID の値。
+     * @throws IllegalArgumentException ID の値が 0 未満の場合。
+     */
+    public Id(long value) {
+        if (value < 0) {
+            throw new IllegalArgumentException("{0} は {1} 以上の値にしてください");
+        }
+        this.value = value;
+    }
 }

--- a/backend/application-core/src/main/java/com/memoblend/applicationcore/diary/valueobject/IsDeleted.java
+++ b/backend/application-core/src/main/java/com/memoblend/applicationcore/diary/valueobject/IsDeleted.java
@@ -1,0 +1,5 @@
+package com.memoblend.applicationcore.diary.valueobject;
+
+public class IsDeleted {
+
+}

--- a/backend/application-core/src/main/java/com/memoblend/applicationcore/diary/valueobject/IsDeleted.java
+++ b/backend/application-core/src/main/java/com/memoblend/applicationcore/diary/valueobject/IsDeleted.java
@@ -3,17 +3,20 @@ package com.memoblend.applicationcore.diary.valueobject;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
+/**
+ * 削除フラグを表す値オブジェクト。
+ */
 @Getter
 @EqualsAndHashCode
 public class IsDeleted {
-    private final boolean value;
+  private final boolean value;
 
-    /**
-     * {@link IsDeleted} クラスの新しいインスタンスを初期化します。
-     * 
-     * @param value 削除フラグの値。
-     */
-    public IsDeleted(boolean value) {
-        this.value = value;
-    }
+  /**
+   * {@link IsDeleted} クラスの新しいインスタンスを初期化します。
+   * 
+   * @param value 削除フラグの値。
+   */
+  public IsDeleted(boolean value) {
+    this.value = value;
+  }
 }

--- a/backend/application-core/src/main/java/com/memoblend/applicationcore/diary/valueobject/IsDeleted.java
+++ b/backend/application-core/src/main/java/com/memoblend/applicationcore/diary/valueobject/IsDeleted.java
@@ -1,5 +1,19 @@
 package com.memoblend.applicationcore.diary.valueobject;
 
-public class IsDeleted {
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
 
+@Getter
+@EqualsAndHashCode
+public class IsDeleted {
+    private final boolean value;
+
+    /**
+     * {@link IsDeleted} クラスの新しいインスタンスを初期化します。
+     * 
+     * @param value 削除フラグの値。
+     */
+    public IsDeleted(boolean value) {
+        this.value = value;
+    }
 }

--- a/backend/application-core/src/main/java/com/memoblend/applicationcore/diary/valueobject/Title.java
+++ b/backend/application-core/src/main/java/com/memoblend/applicationcore/diary/valueobject/Title.java
@@ -1,0 +1,5 @@
+package com.memoblend.applicationcore.diary.valueobject;
+
+public class Title {
+
+}

--- a/backend/application-core/src/main/java/com/memoblend/applicationcore/diary/valueobject/Title.java
+++ b/backend/application-core/src/main/java/com/memoblend/applicationcore/diary/valueobject/Title.java
@@ -1,5 +1,26 @@
 package com.memoblend.applicationcore.diary.valueobject;
 
-public class Title {
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
 
+@Getter
+@EqualsAndHashCode
+public class Title {
+    private final String value;
+
+    /**
+     * {@link Title} クラスの新しいインスタンスを初期化します。
+     * 
+     * @param value タイトルの値。
+     * @throws IllegalArgumentException タイトルの値が null か指定の文字数範囲外の場合。
+     */
+    public Title(String value) {
+        if (value == null || value.isEmpty()) {
+            throw new IllegalArgumentException("{0} は {1} 文字以上入力してください");
+        }
+        if (value.length() < 1 || value.length() > 30) {
+            throw new IllegalArgumentException("{0} は {1} ～ {2} 文字の範囲で入力してください");
+        }
+        this.value = value;
+    }
 }

--- a/backend/application-core/src/main/java/com/memoblend/applicationcore/diary/valueobject/Title.java
+++ b/backend/application-core/src/main/java/com/memoblend/applicationcore/diary/valueobject/Title.java
@@ -3,24 +3,27 @@ package com.memoblend.applicationcore.diary.valueobject;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
+/**
+ * タイトルを表す値オブジェクト。
+ */
 @Getter
 @EqualsAndHashCode
 public class Title {
-    private final String value;
+  private final String value;
 
-    /**
-     * {@link Title} クラスの新しいインスタンスを初期化します。
-     * 
-     * @param value タイトルの値。
-     * @throws IllegalArgumentException タイトルの値が null か指定の文字数範囲外の場合。
-     */
-    public Title(String value) {
-        if (value == null || value.isEmpty()) {
-            throw new IllegalArgumentException("{0} は {1} 文字以上入力してください");
-        }
-        if (value.length() < 1 || value.length() > 30) {
-            throw new IllegalArgumentException("{0} は {1} ～ {2} 文字の範囲で入力してください");
-        }
-        this.value = value;
+  /**
+   * {@link Title} クラスの新しいインスタンスを初期化します。
+   * 
+   * @param value タイトルの値。
+   * @throws IllegalArgumentException タイトルの値が null か指定の文字数範囲外の場合。
+   */
+  public Title(String value) {
+    if (value == null || value.isEmpty()) {
+      throw new IllegalArgumentException("{0} は {1} 文字以上入力してください");
     }
+    if (value.length() < 1 || value.length() > 30) {
+      throw new IllegalArgumentException("{0} は {1} ～ {2} 文字の範囲で入力してください");
+    }
+    this.value = value;
+  }
 }

--- a/backend/application-core/src/main/java/com/memoblend/applicationcore/diary/valueobject/Title.java
+++ b/backend/application-core/src/main/java/com/memoblend/applicationcore/diary/valueobject/Title.java
@@ -18,7 +18,7 @@ public class Title {
    * @throws IllegalArgumentException タイトルの値が null か指定の文字数範囲外の場合。
    */
   public Title(String value) {
-    if (value == null || value.isEmpty()) {
+    if (value == null || value.isEmpty() || value.isBlank()) {
       throw new IllegalArgumentException("{0} は {1} 文字以上入力してください");
     }
     if (value.length() < 1 || value.length() > 30) {

--- a/backend/application-core/src/main/java/com/memoblend/applicationcore/diary/valueobject/UserId.java
+++ b/backend/application-core/src/main/java/com/memoblend/applicationcore/diary/valueobject/UserId.java
@@ -1,0 +1,5 @@
+package com.memoblend.applicationcore.diary.valueobject;
+
+public class UserId {
+
+}

--- a/backend/application-core/src/main/java/com/memoblend/applicationcore/diary/valueobject/UserId.java
+++ b/backend/application-core/src/main/java/com/memoblend/applicationcore/diary/valueobject/UserId.java
@@ -3,21 +3,24 @@ package com.memoblend.applicationcore.diary.valueobject;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
+/**
+ * ユーザー ID を表す値オブジェクト。
+ */
 @Getter
 @EqualsAndHashCode
 public class UserId {
-    private final long value;
+  private final long value;
 
-    /**
-     * {@link UserId} クラスの新しいインスタンスを初期化します。
-     * 
-     * @param value ユーザー ID の値。
-     * @throws IllegalArgumentException ユーザー ID の値が 0 未満の場合。
-     */
-    public UserId(long value) {
-        if (value < 0) {
-            throw new IllegalArgumentException("{0} は {1} 以上の値にしてください");
-        }
-        this.value = value;
+  /**
+   * {@link UserId} クラスの新しいインスタンスを初期化します。
+   * 
+   * @param value ユーザー ID の値。
+   * @throws IllegalArgumentException ユーザー ID の値が 0 未満の場合。
+   */
+  public UserId(long value) {
+    if (value < 0) {
+      throw new IllegalArgumentException("{0} は {1} 以上の値にしてください");
     }
+    this.value = value;
+  }
 }

--- a/backend/application-core/src/main/java/com/memoblend/applicationcore/diary/valueobject/UserId.java
+++ b/backend/application-core/src/main/java/com/memoblend/applicationcore/diary/valueobject/UserId.java
@@ -1,5 +1,23 @@
 package com.memoblend.applicationcore.diary.valueobject;
 
-public class UserId {
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
 
+@Getter
+@EqualsAndHashCode
+public class UserId {
+    private final long value;
+
+    /**
+     * {@link UserId} クラスの新しいインスタンスを初期化します。
+     * 
+     * @param value ユーザー ID の値。
+     * @throws IllegalArgumentException ユーザー ID の値が 0 未満の場合。
+     */
+    public UserId(long value) {
+        if (value < 0) {
+            throw new IllegalArgumentException("{0} は {1} 以上の値にしてください");
+        }
+        this.value = value;
+    }
 }

--- a/backend/application-core/src/test/java/com/memoblend/applicationcore/applicationservice/DiaryApplicationServiceTest.java
+++ b/backend/application-core/src/test/java/com/memoblend/applicationcore/applicationservice/DiaryApplicationServiceTest.java
@@ -102,8 +102,8 @@ public class DiaryApplicationServiceTest {
   @Test
   void testGetDiary_正常系_リポジトリのfindByIdを1回呼び出す() throws DiaryNotFoundException, PermissionDeniedException {
     // Arrange
-    LocalDate date = LocalDate.of(2025, 1, 1);
-    Diary diary = createDiary(date);
+    LocalDate createdDate = LocalDate.of(2025, 1, 1);
+    Diary diary = createDiary(createdDate);
     long id = diary.getId();
     when(diaryRepository.findById(id)).thenReturn(diary);
     when(userStore.isInRole(UserRoleConstants.USER)).thenReturn(true);
@@ -116,8 +116,8 @@ public class DiaryApplicationServiceTest {
   @Test
   void testGetDiary_正常系_指定した日付の日記を返す() throws DiaryNotFoundException, PermissionDeniedException {
     // Arrange
-    LocalDate date = LocalDate.of(2025, 1, 1);
-    Diary diary = createDiary(date);
+    LocalDate createdDate = LocalDate.of(2025, 1, 1);
+    Diary diary = createDiary(createdDate);
     long id = diary.getId();
     when(diaryRepository.findById(id)).thenReturn(diary);
     when(userStore.isInRole(UserRoleConstants.USER)).thenReturn(true);
@@ -144,8 +144,8 @@ public class DiaryApplicationServiceTest {
   @Test
   void testGetDiary_異常系_権限がない場合にPermnissionDeniedExceptionが発生する() {
     // Arrange
-    LocalDate date = LocalDate.of(2025, 1, 1);
-    Diary diary = createDiary(date);
+    LocalDate createdDate = LocalDate.of(2025, 1, 1);
+    Diary diary = createDiary(createdDate);
     long id = diary.getId();
     when(diaryRepository.findById(id)).thenReturn(diary);
     when(userStore.isInRole(UserRoleConstants.USER)).thenReturn(false);
@@ -160,8 +160,8 @@ public class DiaryApplicationServiceTest {
   @Test
   void testAddDiary_正常系_リポジトリのaddを1回呼び出す() throws PermissionDeniedException {
     // Arrange
-    LocalDate date = LocalDate.of(2025, 1, 1);
-    Diary diary = createDiary(date);
+    LocalDate createdDate = LocalDate.of(2025, 1, 1);
+    Diary diary = createDiary(createdDate);
     long id = diary.getId();
     when(diaryDomainService.isExistDiary(id)).thenReturn(false);
     when(diaryRepository.add(diary)).thenReturn(diary);
@@ -175,8 +175,8 @@ public class DiaryApplicationServiceTest {
   @Test
   void testAddDiary_正常系_追加された日記を返す() throws PermissionDeniedException {
     // Arrange
-    LocalDate date = LocalDate.of(2025, 1, 1);
-    Diary diary = createDiary(date);
+    LocalDate createdDate = LocalDate.of(2025, 1, 1);
+    Diary diary = createDiary(createdDate);
     long id = diary.getId();
     when(diaryDomainService.isExistDiary(id)).thenReturn(false);
     when(diaryRepository.add(diary)).thenReturn(diary);
@@ -190,8 +190,8 @@ public class DiaryApplicationServiceTest {
   @Test
   void testAddDiary_異常系_権限がない場合にPermissionDeniedExceptionが発生する() {
     // Arrange
-    LocalDate date = LocalDate.of(2025, 1, 1);
-    Diary diary = createDiary(date);
+    LocalDate createdDate = LocalDate.of(2025, 1, 1);
+    Diary diary = createDiary(createdDate);
     long id = diary.getId();
     when(diaryDomainService.isExistDiary(id)).thenReturn(false);
     when(diaryRepository.add(diary)).thenReturn(diary);
@@ -207,8 +207,8 @@ public class DiaryApplicationServiceTest {
   @Test
   void testUpdateDiary_正常系_リポジトリのupdateを1回呼び出す() throws DiaryNotFoundException, PermissionDeniedException {
     // Arrange
-    LocalDate date = LocalDate.of(2025, 1, 1);
-    Diary diary = createDiary(date);
+    LocalDate createdDate = LocalDate.of(2025, 1, 1);
+    Diary diary = createDiary(createdDate);
     long id = diary.getId();
     when(diaryDomainService.isExistDiary(id)).thenReturn(true);
     when(userStore.isInRole(UserRoleConstants.USER)).thenReturn(true);
@@ -221,8 +221,8 @@ public class DiaryApplicationServiceTest {
   @Test
   void testUpdateDiary_異常系_更新しようとした日記が存在しない場合DiaryNotFoundExceptionがスローされる() {
     // Arrange
-    LocalDate date = LocalDate.of(2025, 1, 1);
-    Diary diary = createDiary(date);
+    LocalDate createdDate = LocalDate.of(2025, 1, 1);
+    Diary diary = createDiary(createdDate);
     long id = diary.getId();
     when(diaryDomainService.isExistDiary(id)).thenReturn(false);
     when(userStore.isInRole(UserRoleConstants.USER)).thenReturn(true);
@@ -237,8 +237,8 @@ public class DiaryApplicationServiceTest {
   @Test
   void testUpdateDiary_異常系_権限がない場合にPermissionDeniedExceptionが発生する() {
     // Arrange
-    LocalDate date = LocalDate.of(2025, 1, 1);
-    Diary diary = createDiary(date);
+    LocalDate createdDate = LocalDate.of(2025, 1, 1);
+    Diary diary = createDiary(createdDate);
     long id = diary.getId();
     when(diaryDomainService.isExistDiary(id)).thenReturn(true);
     when(userStore.isInRole(UserRoleConstants.USER)).thenReturn(false);
@@ -292,18 +292,18 @@ public class DiaryApplicationServiceTest {
 
   private List<Diary> createDiaries(List<LocalDate> dates) {
     List<Diary> diaries = new ArrayList<>();
-    for (LocalDate date : dates) {
-      diaries.add(createDiary(date));
+    for (LocalDate createdDate : dates) {
+      diaries.add(createDiary(createdDate));
     }
     return diaries;
   }
 
-  private Diary createDiary(LocalDate date) {
+  private Diary createDiary(LocalDate createdDate) {
     long id = 1;
     long userId = 1;
     String title = "testTitle";
     String content = "testContent";
-    Diary diary = new Diary(id, userId, title, content, date, false);
+    Diary diary = new Diary(id, userId, title, content, createdDate, false);
     return diary;
   }
 }

--- a/backend/application-core/src/test/java/com/memoblend/applicationcore/diary/DiaryDomainServiceTest.java
+++ b/backend/application-core/src/test/java/com/memoblend/applicationcore/diary/DiaryDomainServiceTest.java
@@ -29,8 +29,8 @@ public class DiaryDomainServiceTest {
   @Test
   void testIsExistDiary_正常系_日記が存在する場合はtrueを返す() {
     // Arrange
-    LocalDate date = LocalDate.of(2025, 1, 1);
-    Diary diary = createDiary(date);
+    LocalDate createdDate = LocalDate.of(2025, 1, 1);
+    Diary diary = createDiary(createdDate);
     long id = diary.getId();
     when(diaryRepository.findById(id)).thenReturn(diary);
     // Act
@@ -50,12 +50,12 @@ public class DiaryDomainServiceTest {
     assertTrue(!actual);
   }
 
-  private Diary createDiary(LocalDate date) {
+  private Diary createDiary(LocalDate createdDate) {
     long id = 1;
     long userId = 1;
     String title = "testTitle";
     String content = "testContent";
-    Diary diary = new Diary(id, userId, title, content, date, false);
+    Diary diary = new Diary(id, userId, title, content, createdDate, false);
     return diary;
   }
 }

--- a/backend/application-core/src/test/java/com/memoblend/applicationcore/diary/DiaryTest.java
+++ b/backend/application-core/src/test/java/com/memoblend/applicationcore/diary/DiaryTest.java
@@ -1,196 +1,109 @@
 package com.memoblend.applicationcore.diary;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import java.time.LocalDate;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
-import org.springframework.validation.BindException;
-import org.springframework.validation.BindingResult;
-import org.springframework.validation.Validator;
-import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
 
 /**
- * 日記のドメインモデルのテストクラスです。
+ * Diary クラスのテストクラスです。
  */
-@ExtendWith(SpringExtension.class)
 public class DiaryTest {
 
-  private Diary diary;
-  private BindingResult bindingResult;
-  private Validator validator;
-
-  @BeforeEach
-  void setUp() {
-    this.diary = new Diary(1L, 1L, "testTitle", "testContent", LocalDate.of(2025, 1, 1), false);
-    this.bindingResult = new BindException(diary, "Diary");
-    setUpValidator();
-  }
-
   @Test
-  public void testNoError_正常系_日記を作成できた場合はtrueを返す() {
-    // Act
-    validator.validate(diary, bindingResult);
-    // Assert
-    assertTrue(!bindingResult.hasErrors());
+  public void testNoError_正常系_日記を作成できる() {
+    assertDoesNotThrow(() -> new Diary(1L, 1L, "testTitle", "testContent", LocalDate.of(2025, 1, 1), false));
   }
 
   @Test
   public void testIdSetZero_正常系_idが0() {
-    // Arrange
-    diary.setId(0L);
-    // Act
-    validator.validate(diary, bindingResult);
-    // Assert
-    assertTrue(!bindingResult.hasErrors());
+    assertDoesNotThrow(() -> new Diary(0L, 1L, "testTitle", "testContent", LocalDate.of(2025, 1, 1), false));
   }
 
   @Test
   public void testIdIsNegative_異常系_IDが負の数() {
-    // Arrange
-    diary.setId(-1L);
-    // Act
-    validator.validate(diary, bindingResult);
-    // Assert
-    assertEquals("id", bindingResult.getFieldError().getField());
-    assertEquals("{0} は {1} 以上の値にしてください", bindingResult.getFieldError().getDefaultMessage());
+    IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+        () -> new Diary(-1L, 1L, "testTitle", "testContent", LocalDate.of(2025, 1, 1), false));
+    assertEquals("{0} は {1} 以上の値にしてください", e.getMessage());
   }
 
   @Test
   public void testUserIdSetZero_正常系_userIdが0() {
-    // Arrange
-    diary.setUserId(0L);
-    // Act
-    validator.validate(diary, bindingResult);
-    // Assert
-    assertTrue(!bindingResult.hasErrors());
+    assertDoesNotThrow(() -> new Diary(1L, 0L, "testTitle", "testContent", LocalDate.of(2025, 1, 1), false));
   }
 
   @Test
-  public void testUserIdIsNull_異常系_userIdが負の数() {
-    // Arrange
-    diary.setUserId(-1L);
-    // Act
-    validator.validate(diary, bindingResult);
-    // Asert
-    assertEquals("userId", bindingResult.getFieldError().getField());
-    assertEquals("{0} は {1} 以上の値にしてください", bindingResult.getFieldError().getDefaultMessage());
+  public void testUserIdIsNegative_異常系_userIdが負の数() {
+    IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+        () -> new Diary(1L, -1L, "testTitle", "testContent", LocalDate.of(2025, 1, 1), false));
+    assertEquals("{0} は {1} 以上の値にしてください", e.getMessage());
   }
 
   @Test
   public void testTitleIsNull_異常系_titleがnull() {
-    // Arrange
-    diary.setTitle(null);
-    // Act
-    validator.validate(diary, bindingResult);
-    // Assert
-    assertEquals("title", bindingResult.getFieldError().getField());
-    assertEquals("{0}は {1} ～ {2} 文字の範囲で入力してください", bindingResult.getFieldError().getDefaultMessage());
+    IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+        () -> new Diary(1L, 1L, null, "testContent", LocalDate.of(2025, 1, 1), false));
+    assertEquals("{0} は {1} 文字以上入力してください", e.getMessage());
   }
 
   @Test
   public void testTitleIsBlank_異常系_titleが空白() {
-    // Arrange
-    diary.setTitle(" ");
-    // Act
-    validator.validate(diary, bindingResult);
-    // Assert
-    assertEquals("title", bindingResult.getFieldError().getField());
-    assertEquals("{0} は {1} ～ {2} 文字の範囲で入力してください", bindingResult.getFieldError().getDefaultMessage());
+    IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+        () -> new Diary(1L, 1L, " ", "testContent", LocalDate.of(2025, 1, 1), false));
+    assertEquals("{0} は {1} 文字以上入力してください", e.getMessage());
   }
 
   @Test
   public void testTitleIsTooShort_異常系_titleが0文字() {
-    // Arrange
-    diary.setTitle("");
-    // Act
-    validator.validate(diary, bindingResult);
-    // Assert
-    assertEquals("title", bindingResult.getFieldError().getField());
-    assertEquals("{0} は {1} ～ {2} 文字の範囲で入力してください", bindingResult.getFieldError().getDefaultMessage());
+    IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+        () -> new Diary(1L, 1L, "", "testContent", LocalDate.of(2025, 1, 1), false));
+    assertEquals("{0} は {1} 文字以上入力してください", e.getMessage());
   }
 
   @Test
   public void testTitleIsTooLong_異常系_titleの文字数オーバー() {
-    // Arrange
-    diary.setTitle("a".repeat(999));
-    // Act
-    validator.validate(diary, bindingResult);
-    // Assert
-    assertEquals("title", bindingResult.getFieldError().getField());
-    assertEquals("{0} は {1} ～ {2} 文字の範囲で入力してください", bindingResult.getFieldError().getDefaultMessage());
+    IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+        () -> new Diary(1L, 1L, "a".repeat(101), "testContent", LocalDate.of(2025, 1, 1), false));
+    assertEquals("{0} は {1} ～ {2} 文字の範囲で入力してください", e.getMessage());
   }
 
   @Test
   public void testContentIsNull_異常系_contentがnull() {
-    // Arrange
-    diary.setContent(null);
-    // Act
-    validator.validate(diary, bindingResult);
-    // Assert
-    assertEquals("content", bindingResult.getFieldError().getField());
-    assertEquals("{0} は {1} 文字以上入力してください", bindingResult.getFieldError().getDefaultMessage());
+    IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+        () -> new Diary(1L, 1L, "testTitle", null, LocalDate.of(2025, 1, 1), false));
+    assertEquals("{0} は {1} 文字以上入力してください", e.getMessage());
   }
 
   @Test
   public void testContentIsBlank_異常系_contentが空白() {
-    // Arrange
-    diary.setContent(" ");
-    // Act
-    validator.validate(diary, bindingResult);
-    // Assert
-    assertEquals("content", bindingResult.getFieldError().getField());
-    assertEquals("{0} は {1} 文字以上入力してください", bindingResult.getFieldError().getDefaultMessage());
+    IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+        () -> new Diary(1L, 1L, "testTitle", " ", LocalDate.of(2025, 1, 1), false));
+    assertEquals("{0} は {1} 文字以上入力してください", e.getMessage());
   }
 
   @Test
   public void testContentIsTooShort_異常系_contentが0文字() {
-    // Arrange
-    diary.setContent("");
-    // Act
-    validator.validate(diary, bindingResult);
-    // Assert
-    assertEquals("content", bindingResult.getFieldError().getField());
-    assertEquals("{0} は {1} 文字以上入力してください", bindingResult.getFieldError().getDefaultMessage());
+    IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+        () -> new Diary(1L, 1L, "testTitle", "", LocalDate.of(2025, 1, 1), false));
+    assertEquals("{0} は {1} 文字以上入力してください", e.getMessage());
   }
 
   @Test
   public void testDateIsNull_異常系_日付がnull() {
-    // Arrange
-    diary.setCreatedDate(null);
-    // Act
-    validator.validate(diary, bindingResult);
-    // Assert
-    assertEquals("date", bindingResult.getFieldError().getField());
-    assertEquals("{0} は必須です", bindingResult.getFieldError().getDefaultMessage());
+    IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+        () -> new Diary(1L, 1L, "testTitle", "testContent", null, false));
+    assertEquals("{0} は必須です", e.getMessage());
   }
 
   @Test
   public void testIsDeletedIsFalse_正常系_isDeletedがfalse() {
-    // Arrange
-    diary.setIsDeleted(false);
-    // Act
-    validator.validate(diary, bindingResult);
-    // Assert
-    assertTrue(!bindingResult.hasErrors());
+    assertDoesNotThrow(() -> new Diary(1L, 1L, "testTitle", "testContent", LocalDate.of(2025, 1, 1), false));
   }
 
   @Test
   public void testIsDeletedIsTrue_正常系_isDeletedがtrue() {
-    // Arrange
-    diary.setIsDeleted(true);
-    // Act
-    validator.validate(diary, bindingResult);
-    // Assert
-    assertTrue(!bindingResult.hasErrors());
-  }
-
-  private void setUpValidator() {
-    LocalValidatorFactoryBean factory = new LocalValidatorFactoryBean();
-    factory.afterPropertiesSet();
-    this.validator = factory;
+    assertDoesNotThrow(() -> new Diary(1L, 1L, "testTitle", "testContent", LocalDate.of(2025, 1, 1), true));
   }
 }

--- a/backend/application-core/src/test/java/com/memoblend/applicationcore/diary/DiaryTest.java
+++ b/backend/application-core/src/test/java/com/memoblend/applicationcore/diary/DiaryTest.java
@@ -56,7 +56,7 @@ public class DiaryTest {
     validator.validate(diary, bindingResult);
     // Assert
     assertEquals("id", bindingResult.getFieldError().getField());
-    assertEquals("{0}は0以上の値にしてください", bindingResult.getFieldError().getDefaultMessage());
+    assertEquals("{0} は {1} 以上の値にしてください", bindingResult.getFieldError().getDefaultMessage());
   }
 
   @Test
@@ -77,7 +77,7 @@ public class DiaryTest {
     validator.validate(diary, bindingResult);
     // Asert
     assertEquals("userId", bindingResult.getFieldError().getField());
-    assertEquals("{0}は0以上の値にしてください", bindingResult.getFieldError().getDefaultMessage());
+    assertEquals("{0} は {1} 以上の値にしてください", bindingResult.getFieldError().getDefaultMessage());
   }
 
   @Test
@@ -88,7 +88,7 @@ public class DiaryTest {
     validator.validate(diary, bindingResult);
     // Assert
     assertEquals("title", bindingResult.getFieldError().getField());
-    assertEquals("{0}は1～30文字の範囲で入力してください", bindingResult.getFieldError().getDefaultMessage());
+    assertEquals("{0}は {1} ～ {2} 文字の範囲で入力してください", bindingResult.getFieldError().getDefaultMessage());
   }
 
   @Test
@@ -99,7 +99,7 @@ public class DiaryTest {
     validator.validate(diary, bindingResult);
     // Assert
     assertEquals("title", bindingResult.getFieldError().getField());
-    assertEquals("{0}は1～30文字の範囲で入力してください", bindingResult.getFieldError().getDefaultMessage());
+    assertEquals("{0} は {1} ～ {2} 文字の範囲で入力してください", bindingResult.getFieldError().getDefaultMessage());
   }
 
   @Test
@@ -110,7 +110,7 @@ public class DiaryTest {
     validator.validate(diary, bindingResult);
     // Assert
     assertEquals("title", bindingResult.getFieldError().getField());
-    assertEquals("{0}は1～30文字の範囲で入力してください", bindingResult.getFieldError().getDefaultMessage());
+    assertEquals("{0} は {1} ～ {2} 文字の範囲で入力してください", bindingResult.getFieldError().getDefaultMessage());
   }
 
   @Test
@@ -121,7 +121,7 @@ public class DiaryTest {
     validator.validate(diary, bindingResult);
     // Assert
     assertEquals("title", bindingResult.getFieldError().getField());
-    assertEquals("{0}は1～30文字の範囲で入力してください", bindingResult.getFieldError().getDefaultMessage());
+    assertEquals("{0} は {1} ～ {2} 文字の範囲で入力してください", bindingResult.getFieldError().getDefaultMessage());
   }
 
   @Test
@@ -132,7 +132,7 @@ public class DiaryTest {
     validator.validate(diary, bindingResult);
     // Assert
     assertEquals("content", bindingResult.getFieldError().getField());
-    assertEquals("{0}は1文字以上入力してください", bindingResult.getFieldError().getDefaultMessage());
+    assertEquals("{0} は {1} 文字以上入力してください", bindingResult.getFieldError().getDefaultMessage());
   }
 
   @Test
@@ -143,7 +143,7 @@ public class DiaryTest {
     validator.validate(diary, bindingResult);
     // Assert
     assertEquals("content", bindingResult.getFieldError().getField());
-    assertEquals("{0}は1文字以上入力してください", bindingResult.getFieldError().getDefaultMessage());
+    assertEquals("{0} は {1} 文字以上入力してください", bindingResult.getFieldError().getDefaultMessage());
   }
 
   @Test
@@ -154,24 +154,24 @@ public class DiaryTest {
     validator.validate(diary, bindingResult);
     // Assert
     assertEquals("content", bindingResult.getFieldError().getField());
-    assertEquals("{0}は1文字以上入力してください", bindingResult.getFieldError().getDefaultMessage());
+    assertEquals("{0} は {1} 文字以上入力してください", bindingResult.getFieldError().getDefaultMessage());
   }
 
   @Test
   public void testDateIsNull_異常系_日付がnull() {
     // Arrange
-    diary.setDate(null);
+    diary.setCreatedDate(null);
     // Act
     validator.validate(diary, bindingResult);
     // Assert
     assertEquals("date", bindingResult.getFieldError().getField());
-    assertEquals("{0}は必須です", bindingResult.getFieldError().getDefaultMessage());
+    assertEquals("{0} は必須です", bindingResult.getFieldError().getDefaultMessage());
   }
 
   @Test
   public void testIsDeletedIsFalse_正常系_isDeletedがfalse() {
     // Arrange
-    diary.setDeleted(false);
+    diary.setIsDeleted(false);
     // Act
     validator.validate(diary, bindingResult);
     // Assert
@@ -181,7 +181,7 @@ public class DiaryTest {
   @Test
   public void testIsDeletedIsTrue_正常系_isDeletedがtrue() {
     // Arrange
-    diary.setDeleted(true);
+    diary.setIsDeleted(true);
     // Act
     validator.validate(diary, bindingResult);
     // Assert

--- a/backend/infrastructure/src/main/java/com/memoblend/infrastructure/repository/mapper/DiaryMapper.xml
+++ b/backend/infrastructure/src/main/java/com/memoblend/infrastructure/repository/mapper/DiaryMapper.xml
@@ -14,8 +14,8 @@
 	</select>
 	
 	<insert id="add" parameterType="com.memoblend.applicationcore.diary.Diary" useGeneratedKeys="true" keyProperty="id">
-		INSERT INTO diaries (user_id, title, content, date)
-		VALUES (#{userId}, #{title}, #{content}, #{date})
+		INSERT INTO diaries (user_id, title, content, created_date)
+		VALUES (#{userId}, #{title}, #{content}, #{createdDate})
 	</insert>
 
 	<delete id="delete" parameterType="long">
@@ -26,7 +26,7 @@
 
 	<update id="update" parameterType="com.memoblend.applicationcore.diary.Diary">
 		UPDATE diaries
-		SET title = #{title}, content = #{content}, date = #{date}
+		SET title = #{title}, content = #{content}, created_date = #{createdDate}
 		WHERE id = #{id}
 		AND user_id = #{userId}
 	</update>

--- a/backend/infrastructure/src/main/java/com/memoblend/infrastructure/repository/mapper/DiaryMapper.xml
+++ b/backend/infrastructure/src/main/java/com/memoblend/infrastructure/repository/mapper/DiaryMapper.xml
@@ -18,11 +18,11 @@
 		VALUES (#{userId}, #{title}, #{content}, #{createdDate})
 	</insert>
 
-	<delete id="delete" parameterType="long">
+	<update id="delete" parameterType="long">
 		UPDATE diaries
 		SET is_deleted = true
 		WHERE id = #{id}
-	</delete>
+	</update>
 
 	<update id="update" parameterType="com.memoblend.applicationcore.diary.Diary">
 		UPDATE diaries

--- a/backend/infrastructure/src/main/resources/data.sql
+++ b/backend/infrastructure/src/main/resources/data.sql
@@ -21,7 +21,7 @@ INSERT INTO users (name, is_deleted) VALUES
 ('岡田 大輔', false),
 ('柴田 陽菜', false);
 
-INSERT INTO diaries (user_id, title, content, date, is_deleted) VALUES
+INSERT INTO diaries (user_id, title, content, created_date, is_deleted) VALUES
 (7, '朝の散歩', '今日は近くの公園を散歩しました。空気が澄んでいて気持ちよかったです。', '2025-01-09', false),
 (13, '仕事の進捗', 'プロジェクトの第一フェーズが無事完了しました。次のステップに向けて準備中。', '2025-02-09', false),
 (8, '買い物リスト', '今日はスーパーでりんご、バナナ、オレンジを購入しました。', '2025-01-19', false),

--- a/backend/infrastructure/src/main/resources/schema.sql
+++ b/backend/infrastructure/src/main/resources/schema.sql
@@ -14,6 +14,6 @@ CREATE TABLE diaries
   user_id BIGSERIAL NOT NULL,
   title VARCHAR(64) NOT NULL,
   content VARCHAR NOT NULL,
-  date TIMESTAMP NOT NULL,
+  created_date TIMESTAMP NOT NULL,
   is_deleted BOOLEAN NOT NULL DEFAULT FALSE
 );

--- a/backend/web/src/main/java/com/memoblend/web/controller/dto/diary/GetDiaryResponse.java
+++ b/backend/web/src/main/java/com/memoblend/web/controller/dto/diary/GetDiaryResponse.java
@@ -14,5 +14,5 @@ public class GetDiaryResponse {
   private long userId;
   private String title;
   private String content;
-  private LocalDate date;
+  private LocalDate createdDate;
 }

--- a/backend/web/src/main/java/com/memoblend/web/controller/dto/diary/PostDiaryRequest.java
+++ b/backend/web/src/main/java/com/memoblend/web/controller/dto/diary/PostDiaryRequest.java
@@ -13,5 +13,5 @@ public class PostDiaryRequest {
   private long userId;
   private String title;
   private String content;
-  private LocalDate date;
+  private LocalDate createdDate;
 }

--- a/backend/web/src/main/java/com/memoblend/web/controller/dto/diary/PutDiaryRequest.java
+++ b/backend/web/src/main/java/com/memoblend/web/controller/dto/diary/PutDiaryRequest.java
@@ -14,5 +14,5 @@ public class PutDiaryRequest {
   private long userId;
   private String title;
   private String content;
-  private LocalDate date;
+  private LocalDate createdDate;
 }

--- a/backend/web/src/main/java/com/memoblend/web/controller/mapper/diary/GetDiaryReponseMapper.java
+++ b/backend/web/src/main/java/com/memoblend/web/controller/mapper/diary/GetDiaryReponseMapper.java
@@ -20,7 +20,7 @@ public class GetDiaryReponseMapper {
         diary.getUserId(),
         diary.getTitle(),
         diary.getContent(),
-        diary.getDate());
+        diary.getCreatedDate());
     return response;
   }
 }

--- a/backend/web/src/main/java/com/memoblend/web/controller/mapper/diary/PostDiaryRequestMapper.java
+++ b/backend/web/src/main/java/com/memoblend/web/controller/mapper/diary/PostDiaryRequestMapper.java
@@ -20,7 +20,7 @@ public class PostDiaryRequestMapper {
         request.getUserId(),
         request.getTitle(),
         request.getContent(),
-        request.getDate(),
+        request.getCreatedDate(),
         false);
     return diary;
   }

--- a/backend/web/src/main/java/com/memoblend/web/controller/mapper/diary/PutDiaryRequestMapper.java
+++ b/backend/web/src/main/java/com/memoblend/web/controller/mapper/diary/PutDiaryRequestMapper.java
@@ -20,7 +20,7 @@ public class PutDiaryRequestMapper {
         request.getUserId(),
         request.getTitle(),
         request.getContent(),
-        request.getDate(),
+        request.getCreatedDate(),
         false);
     return diary;
   }

--- a/backend/web/src/test/java/com/memoblend/web/controller/DiaryControllerTest.java
+++ b/backend/web/src/test/java/com/memoblend/web/controller/DiaryControllerTest.java
@@ -74,7 +74,7 @@ public class DiaryControllerTest {
         + "\"userId\": 1, "
         + "\"title\": \"Test title\", "
         + "\"content\": \"Test content\", "
-        + "\"date\": \"2025-01-01\""
+        + "\"createdDate\": \"2025-01-01\""
         + "}";
     this.mockMvc.perform(post("/api/diary")
         .contentType(MediaType.APPLICATION_JSON)
@@ -89,7 +89,7 @@ public class DiaryControllerTest {
         + "\"userId\": 1, "
         + "\"title\": \"Test title\", "
         + "\"content\": \"Test content\", "
-        + "\"date\": \"2025-01-01\""
+        + "\"createdDate\": \"2025-01-01\""
         + "}";
     this.mockMvc.perform(post("/api/diary")
         .contentType(MediaType.APPLICATION_JSON)
@@ -128,7 +128,7 @@ public class DiaryControllerTest {
         + "\"userId\": 1, "
         + "\"title\": \"Test title\", "
         + "\"content\": \"Test content\", "
-        + "\"date\": \"2025-01-01\""
+        + "\"createdDate\": \"2025-01-01\""
         + "}";
     this.mockMvc.perform(put("/api/diary")
         .contentType(MediaType.APPLICATION_JSON)
@@ -144,7 +144,7 @@ public class DiaryControllerTest {
         + "\"userId\": 1, "
         + "\"title\": \"Test title\", "
         + "\"content\": \"Test content\", "
-        + "\"date\": \"2025-01-01\""
+        + "\"createdDate\": \"2025-01-01\""
         + "}";
     this.mockMvc.perform(put("/api/diary")
         .contentType(MediaType.APPLICATION_JSON)
@@ -159,7 +159,7 @@ public class DiaryControllerTest {
         + "\"userId\": 1, "
         + "\"title\": \"Test title\", "
         + "\"content\": \"Test content\", "
-        + "\"date\": \"2025-01-01\""
+        + "\"createdDate\": \"2025-01-01\""
         + "}";
     this.mockMvc.perform(put("/api/diary")
         .contentType(MediaType.APPLICATION_JSON)


### PR DESCRIPTION
## 本プルリクエストで実施したこと
- 日記の値オブジェクトを実装し、ドメインオブジェクトの構造を変更しました。

## 本プルリクエストで実施していないこと
- 例外メッセージの定数管理は本PRでは対応していません。

## 関連Issue、参考ページ
- [ ] #279 